### PR TITLE
Try to detect 64-bit version of Windows.

### DIFF
--- a/dolweb/downloads/templates/downloads-index.html
+++ b/dolweb/downloads/templates/downloads-index.html
@@ -27,6 +27,13 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
     <h1>{% trans "Download" %}</h1>
 </div>
 
+{% if USER_OS == "win" %}
+<div class="alert alert-warning">{% blocktrans %}
+    You appear to be running a 32-bit version of Windows. Dolphin no longer
+    supports such operating systems, please update to a 64-bit version.
+{% endblocktrans %}</div>
+{% endif %}
+
 <div id="download-dev">
 <h1>{% trans "Development versions" %}</h1>
 

--- a/dolweb/downloads/templates/downloads-links.html
+++ b/dolweb/downloads/templates/downloads-links.html
@@ -1,5 +1,5 @@
 {% if ver.win64_url %}
-<a class="btn always-ltr {% if USER_OS == "unknown" or USER_OS == "win" %}{{ primclass|default:"btn-primary" }}{% endif %} x64" href="{{ ver.win64_url }}"><i class="icon-download-alt {% if USER_OS != "osx" and USER_OS != "ubu" %}icon-white{% endif %}"></i> Windows x64</a>
+<a class="btn always-ltr {% if USER_OS == "unknown" or USER_OS == "win64" %}{{ primclass|default:"btn-primary" }}{% endif %} x64" href="{{ ver.win64_url }}"><i class="icon-download-alt {% if USER_OS != "osx" and USER_OS != "ubu" %}icon-white{% endif %}"></i> Windows x64</a>
 {% endif %}
 {% if ver.win32_url %}
 <a class="btn always-ltr {% if USER_OS == "unknown" or USER_OS == "win" %}{{ primclass|default:"btn-primary" }}{% endif %} x86" href="{{ ver.win32_url }}"><i class="icon-download-alt {% if USER_OS != "osx" and USER_OS != "ubu" %}icon-white{% endif %}"></i> Windows x86</a>

--- a/dolweb/utils/context_processors.py
+++ b/dolweb/utils/context_processors.py
@@ -19,7 +19,10 @@ def guess_system_from_ua(request):
         return { "USER_OS": "unknown" }
 
     if "Windows" in ua:
-        return { "USER_OS": "win" }
+        if "WOW64" in ua or "Win64" in ua or "x64" in ua:
+            return { "USER_OS": "win64" }
+        else:
+            return { "USER_OS": "win" }
     elif "Macintosh" in ua:
         return { "USER_OS": "osx" }
     elif "Ubuntu" in ua:


### PR DESCRIPTION
If 64-bit version is not detected, display a warning at the top of the download page.

Detection should work with all modern browsers: [Internet Explorer](http://www.useragentstring.com/pages/Internet%20Explorer/) (7 and later), [Chrome](http://www.useragentstring.com/pages/Chrome/) and [Firefox](http://www.useragentstring.com/pages/Firefox/) (4 and later).

One note about Chrome, the [check may fail on very old 32-bit versions](https://code.google.com/p/chromium/issues/detail?id=56515) (older than 2011) running on 64-bit operating systems.
