### PR TITLE
Fixed issue #11 with bootstrap button being too far to the right.

### DIFF
--- a/dolweb/static/css/dolphin.css
+++ b/dolweb/static/css/dolphin.css
@@ -454,10 +454,6 @@ a.navbar-logo {
         font-size: 0.9em;
     }
 
-    #navbar-dolphin .container {
-        max-width: 1100px;
-    }
-
     #navbar-dolphin .dropdown-toggle span {
         display: none;
     }
@@ -466,11 +462,6 @@ a.navbar-logo {
 @media (max-width: 1000px) {
     #navbar-dolphin {
         font-size: 0.7em;
-    }
-
-    #navbar-dolphin .container {
-        width: 768px;
-        max-width: 950px;
     }
 
     #navbar-dolphin .nav > li > a {


### PR DESCRIPTION
The problem is that the button's parent container had a fixed width. So the button would inherit that width, and be stuck way over on the right.