### PR TITLE
Changed download page to add wiki link for older ubuntu users

### DIFF
--- a/dolweb/downloads/templates/downloads-index.html
+++ b/dolweb/downloads/templates/downloads-index.html
@@ -87,6 +87,15 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 </table>
 </div>
 
+<div id="other-linux">
+    <h1>{% trans "Older Ubuntu (< 15.04) and users of other Linux distributions" %}</h1>
+    <p>{% blocktrans %}Ubuntu 14.10 and older users can install a PPA 
+    for development and stable versions of Dolphin here: <a href="https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu">Installing Dolphin</a>
+    {% endblocktrans %}</p>
+    <p>{% blocktrans %}Users of other Linux distributions can look here to compile Dolphin: <a href="https://wiki.dolphin-emu.org/index.php?title=Building_Dolphin_on_Linux">Building Dolphin on Linux</a>
+    {% endblocktrans %}</p>
+</div>   
+
 <div id="download-source">
     <h1>{% trans "Source code" %}</h1>
 


### PR DESCRIPTION
Also added wiki link for other distro users to compile dolphin.

I find it very unfortunate that Ubuntu 14.04 LTS users have no immediate direction for installing Dolphin. I know we're not technically supporting them but I feel like there should be an easy way for LTS users to still receive support. Sergio-br2 maintains the PPA and it has been kept up to date for awhile now. It also seems to be kept more up to date then Glennric's PPA. He has also said that he intends on staying with LTS releases.
