### PR TITLE
Generate URLs pointing to the rev number rather than the hash

### DIFF
--- a/dolweb/downloads/models.py
+++ b/dolweb/downloads/models.py
@@ -67,7 +67,7 @@ class DevVersion(DownloadableVersion):
 
     @models.permalink
     def get_absolute_url(self):
-        return ('downloads_view_devrel', (), { 'hash': self.hash })
+        return ('downloads_view_devrel_by_name', (), {'branch': self.branch, 'name': self.shortrev})
 
     @property
     def description_abbrev(self):


### PR DESCRIPTION
for dev versions, since every user refers to the commit number rather than the hash, it would be more logical to use it in urls too.