### PR TITLE
Modified download page to link to VS2015 runtimes

### DIFF
--- a/dolweb/downloads/templates/downloads-index.html
+++ b/dolweb/downloads/templates/downloads-index.html
@@ -31,10 +31,13 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 <h1>{% trans "Development versions" %}</h1>
 
 <div class="alert">{% blocktrans %}
-    Development versions are released every time a developer makes a change to
+    <p>Development versions are released every time a developer makes a change to
     Dolphin, several times every day! Using development versions enables you to
     use the latest and greatest improvements to the project. They are however
-    less tested than stable versions of the emulator.
+    less tested than stable versions of the emulator.</p>
+
+    <p>The development versions require the <a href="https://www.microsoft.com/en-us/download/details.aspx?id=48145">64-bit Visual C++ redistributable for Visual Studio 2015</a>
+    to be installed.</p>
 {% endblocktrans %}</div>
 
 {% include "downloads-devrel.html" with builds=master_builds primclass='btn-info' %}


### PR DESCRIPTION
There's one issue I know this PR has that I think we should discuss, and that is how we link to the download. My concern is that users won't read and will download the 32 bit version by accident. Some possible solutions I can think of are:
1. Tell users to download the 64 bit runtime in the text (Done in this PR)
2. Directly link to the 64 bit version of the download (This link looks like it can break)
3. Host the runtime our selves and link to that

Any opinions?
