### PR TITLE
downloads: make the VC++ runtime notice red

### DIFF
--- a/dolweb/downloads/templates/downloads-index.html
+++ b/dolweb/downloads/templates/downloads-index.html
@@ -36,7 +36,7 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
     use the latest and greatest improvements to the project. They are however
     less tested than stable versions of the emulator.</p>
 
-    <p>The development versions require the <a href="https://www.microsoft.com/en-us/download/details.aspx?id=48145">64-bit Visual C++ redistributable for Visual Studio 2015</a>
+    <p style="color:red">The development versions for Windows require the <a href="https://www.microsoft.com/en-us/download/details.aspx?id=48145">64-bit Visual C++ redistributable for Visual Studio 2015</a>
     to be installed.</p>
 {% endblocktrans %}</div>
 


### PR DESCRIPTION
Too many people don't read the notice. Maybe this will help...