### PR TITLE
downloads: Show precise timestamp on hover.

### DIFF
--- a/dolweb/downloads/templates/downloads-devrel.html
+++ b/dolweb/downloads/templates/downloads-devrel.html
@@ -6,7 +6,7 @@
     {% for ver in builds %}
         <tr class="infos">
             <td class="version always-ltr"><a href="{{ ver.get_absolute_url }}">{{ ver.shortrev }}</a></td>
-            <td class="reldate">{{ ver.date|naturaltime }}</td>
+            <td class="reldate" title="{{ ver.date|date:"c" }}">{{ ver.date|naturaltime }}</td>
             <td class="description always-ltr">{{ ver.description_abbrev }}</td>
         </tr>
         <tr class="download">

--- a/dolweb/downloads/templates/downloads-view-devrel.html
+++ b/dolweb/downloads/templates/downloads-view-devrel.html
@@ -34,7 +34,7 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
             <dd>{{ ver.branch }}
 
             <dt>{% trans "Date" %}
-            <dd>{{ ver.date|naturaltime }}
+            <dd title="{{ ver.date|date:"c" }}">{{ ver.date|naturaltime }}
 
         </dl>
 


### PR DESCRIPTION
Fixes #9057.

@MaJoRoesch