### PR TITLE
Normalize downloads page

### DIFF
--- a/dolweb/downloads/templates/downloads-index.html
+++ b/dolweb/downloads/templates/downloads-index.html
@@ -30,11 +30,11 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 <div id="download-stable">
 <h1>{% trans "Stable versions" %}</h2>
 
-<div class="alert alert-info">{% blocktrans %}
+<p>{% blocktrans %}
     Stable versions are released after a lot of testing to ensure emulation
     performance and stability. However, since they are released less often,
     they might be outdated and lacking some new features.
-{% endblocktrans %}</div>
+{% endblocktrans %}</p>
 
 <table class="versions-list stable-versions">
     <tbody>
@@ -75,15 +75,15 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 <div id="download-dev">
 <h1>{% trans "Development versions" %}</h1>
 
-<div class="alert">{% blocktrans %}
-    <p>Development versions are released every time a developer makes a change to
-    Dolphin, several times every day! Using development versions enables you to
-    use the latest and greatest improvements to the project. They are however
-    less tested than stable versions of the emulator.</p>
+{% blocktrans %}
+<p>Development versions are released every time a developer makes a change to
+Dolphin, several times every day! Using development versions enables you to
+use the latest and greatest improvements to the project. They are however
+less tested than stable versions of the emulator.</p>
 
-    <p>The development versions require the <a href="https://www.microsoft.com/en-us/download/details.aspx?id=48145">64-bit Visual C++ redistributable for Visual Studio 2015</a>
-    to be installed.</p>
-{% endblocktrans %}</div>
+<p>The development versions require the <a href="https://www.microsoft.com/en-us/download/details.aspx?id=48145">64-bit Visual C++ redistributable for Visual Studio 2015</a>
+to be installed.</p>
+{% endblocktrans %}
 
 {% include "downloads-devrel.html" with builds=master_builds primclass='btn-info' %}
 

--- a/dolweb/static/css/dolphin.css
+++ b/dolweb/static/css/dolphin.css
@@ -129,14 +129,6 @@ h3:hover a.headerlink, h4:hover a.headerlink {
     padding-bottom: 0.5em;
 }
 
-div#download-stable, div#download-dev {
-    margin-bottom: 3em;
-}
-
-div#download-stable h1, div#download-dev h1, div#download-source h1 {
-    margin-bottom: 0.5em;
-}
-
 .versions-list tr:first-child {
     border-top: 1px solid #CCC;
 }


### PR DESCRIPTION
- I don't think `.alert` was supposed to be used alone, because it causes a shadow without any color modifiers. [It is very faint, but it is there](http://imgur.com/a/7ZMrB)
- Replacing the other `.alert` div with a p tag also makes all the text line up with the left
- I removed `margin-bottom: 3em` because it's too big (for me) to separate sections, plus the h1 tags already signify a section, so there should be no need for this space.
- Removing `margin-bottom: 3em` and `margin-bottom: 0.5em` also makes all of the sections equal.
- To me, it looks a lot cleaner than before.

You can reject this PR if you want, I just noticed these and wanted to fix it.

Before: 
![screenshot](https://cloud.githubusercontent.com/assets/4411333/17044586/a8fb9466-4f7e-11e6-92e4-7b5a7daab321.png)
After: 
![screenshot](https://cloud.githubusercontent.com/assets/4411333/17044977/4c459eac-4f82-11e6-90d9-5c05cf428a4e.png)
