### PR TITLE
Downloads: Clarify that the instructions apply to all Linux distros

### DIFF
--- a/dolweb/downloads/templates/downloads-index.html
+++ b/dolweb/downloads/templates/downloads-index.html
@@ -91,13 +91,13 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 </div>
 
 <div id="other-linux">
-    <h1>{% trans "Older Ubuntu (< 15.04) and users of other Linux distributions" %}</h1>
-    <p>{% blocktrans %}Ubuntu 14.10 and older users can install a PPA 
+    <h1>{% trans "Linux distributions" %}</h1>
+    <p>{% blocktrans %}Ubuntu users can install a PPA
     for development and stable versions of Dolphin here: <a href="https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu">Installing Dolphin</a>
     {% endblocktrans %}</p>
     <p>{% blocktrans %}Users of other Linux distributions can look here to compile Dolphin: <a href="https://wiki.dolphin-emu.org/index.php?title=Building_Dolphin_on_Linux">Building Dolphin on Linux</a>
     {% endblocktrans %}</p>
-</div>   
+</div>
 
 <div id="download-source">
     <h1>{% trans "Source code" %}</h1>


### PR DESCRIPTION
Now that we have stopped offering .debs for Ubuntu 15.04, it doesn't make sense anymore to limit the Linux instructions to older Ubuntu versions and other Linux distros. Instead, that section now applies to all Linux distributions.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/www/64)

<!-- Reviewable:end -->
