### PR TITLE
CSS: Hide ¶ from H5 headings as well

### DIFF
--- a/dolweb/static/css/dolphin.css
+++ b/dolweb/static/css/dolphin.css
@@ -74,14 +74,16 @@ html[dir="rtl"] th {
 }
 
 h1 a.headerlink, h2 a.headerlink,
-h3 a.headerlink, h4 a.headerlink {
+h3 a.headerlink, h4 a.headerlink,
+h5 a.headerlink {
     margin-left: 0.5em;
     font-size: 60%;
     visibility: hidden;
 }
 
 h1:hover a.headerlink, h2:hover a.headerlink,
-h3:hover a.headerlink, h4:hover a.headerlink {
+h3:hover a.headerlink, h4:hover a.headerlink,
+h5:hover a.headerlink {
     visibility: visible;
 }
 


### PR DESCRIPTION
This hides ¶ header links from `<h5>`s and make them show on hover, just like with h1, h2, h3 and h4s.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/www/66)

<!-- Reviewable:end -->
