### PR TITLE
[Downloads] Add build list page for bisect tool

### DIFF
--- a/dolweb/downloads/urls.py
+++ b/dolweb/downloads/urls.py
@@ -13,4 +13,5 @@ urlpatterns = patterns('dolweb.downloads.views',
         name='downloads_view_devrel_by_name'),
 
     url(r'^latest/(?P<branch>[a-zA-Z0-9_-]+)/$', 'get_latest', name='downloads_get_latest'),
+    url(r'^buildlist$', 'buildlist', name='buildlist_index'),
 )

--- a/dolweb/downloads/views.py
+++ b/dolweb/downloads/views.py
@@ -1,7 +1,7 @@
 from annoying.decorators import render_to
 from django.conf import settings
 from django.core.paginator import EmptyPage
-from django.http import Http404, HttpResponse
+from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 from dolweb.downloads.diggpaginator import DiggPaginator
@@ -39,6 +39,11 @@ def branches(request):
         ))
 
     return { 'branches': branches }
+
+def buildlist(request):
+    """Displays a list of builds from buildbot for the bisect tool"""
+    master_builds = DevVersion.objects.filter(branch='master').order_by('-date')
+    return JsonResponse(master_builds, safe=True)
 
 @render_to('downloads-view-devrel.html')
 def view_dev_release(request, hash):


### PR DESCRIPTION
URL will be https://www.dolphin-emu.org/downloads/buildlist and it returns nothing but a list of all downloadable build numbers. For the sake of being nicer on bandwidth I've excluded the URL from returning for every build and will just handle that in my tool.


Please check to see if this looks sane. I think I made it work on my system but I'm not sure.