### PR TITLE
[Buildlist] Fix Buildlist page

### DIFF
--- a/dolweb/downloads/views.py
+++ b/dolweb/downloads/views.py
@@ -45,7 +45,10 @@ def branches(request):
 def buildlist(request):
     """Displays a list of builds from buildbot for the bisect tool"""
     master_builds = DevVersion.objects.filter(branch='master').order_by('-date')
-    return JsonResponse(master_builds, safe=True)
+    shortrev_list = []
+    for build in master_builds:
+        shortrev_list.append(build.shortrev)
+    return JsonResponse(shortrev_list, safe=False)
 
 @render_to('downloads-view-devrel.html')
 def view_dev_release(request, hash):


### PR DESCRIPTION
This fixes the broken buildlist page I got merged awhile back. I'm not sure if there is a good way to get what I want into a dict (which plays nice with JsonResponse) rather than a list. Nor do I know if this is the most efficient way to do so.

This time I made a much more sane way of testing to replicate the data that would be in the DB. I copied and modified send_build.py from the sadm repo to send valid "builds" to my local copy of the website. My modifications mostly consisted of removing the hmac stuff temporarily. [Here's the send_build.py code I used.](https://hastebin.com/upufoyimer.py)

So I'm pretty sure this time I'm testing with valid data.