### PR TITLE
static: Add common CSS for images, videos, embeds

### DIFF
--- a/dolweb/static/css/dolphin.css
+++ b/dolweb/static/css/dolphin.css
@@ -557,6 +557,76 @@ div.draft-warning {
     animation: blink 1.5s step-start 0s infinite;
 }
 
+.entry-body .media-block {
+    margin-top: 2em;
+    margin-bottom: 2em;
+}
+
+@media (min-width: 768px) {
+    .entry-body .media-block {
+        max-width: 600px;
+        margin-left: auto;
+        margin-right: auto;
+    }
+
+    /* Modifiers, because the embed size depends on what is getting embedded */
+    .entry-body .media-block.narrower {
+        max-width: 510px;
+    }
+    .entry-body .media-block.wide {
+        max-width: 680px;
+    }
+    .entry-body .media-block.wider {
+        max-width: 720px;
+    }
+    .entry-body .media-block.full-width {
+        max-width: 90%;
+    }
+}
+
+.entry-body figure {
+    text-align: center;
+    margin-bottom: 1em;
+}
+
+.entry-body figure a {
+    text-decoration: none;
+}
+
+.entry-body figure figcaption {
+    margin-top: 0.5em;
+}
+
+.entry-body figure img {
+    max-width: 100%;
+    border-style: none;
+}
+
+@media (min-width: 1200px) {
+    .entry-body .row.more-padding {
+        margin-right: -25px;
+        margin-left: -25px;
+    }
+    .entry-body .row.more-padding > [class^="col-"],
+    .entry-body .row.more-padding > [class^=" col-"] {
+        padding-right: 25px;
+        padding-left: 25px;
+    }
+}
+
+/* Reduce the amount of wasted space on small screens */
+@media (max-width: 768px) {
+    .entry-body .row {
+        margin-right: -8px;
+        margin-left: -8px;
+    }
+    .entry-body .row > [class^="col-"],
+    .entry-body .row > [class^=" col-"] {
+        padding-right: 8px;
+        padding-left: 8px;
+    }
+}
+
 /* rss orange */
 .rss-tag {
     display: inline-block;


### PR DESCRIPTION
Compared to the previous approach of using inline styles everywhere, this provides less style duplication, better mobile support, and encourages the use of semantic tags instead of just `<div>`s and `<p>`s.

The layout is simpler to understand without all the inline styles and `<br>`s and also easier to maintain.

This also enables styling to be more consistent for different kinds of embeds (images, videos, iframe embeds such as gifs).