### PR TITLE
downloads: Update C++ Redistributable to VS 2017

### DIFF
--- a/dolweb/downloads/templates/downloads-index.html
+++ b/dolweb/downloads/templates/downloads-index.html
@@ -81,7 +81,7 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
     use the latest and greatest improvements to the project. They are however
     less tested than stable versions of the emulator.</p>
 
-    <p>The development versions require the <a href="https://www.microsoft.com/en-us/download/details.aspx?id=48145">64-bit Visual C++ redistributable for Visual Studio 2015</a>
+    <p>The development versions require the <a href="https://go.microsoft.com/fwlink/?LinkId=746572">64-bit Visual C++ redistributable for Visual Studio 2017</a>
     to be installed.</p>
 {% endblocktrans %}</div>
 


### PR DESCRIPTION
Updated the link from 64-bit Visual C++ redistributable 2015 to 2017.

Fixes Issue #75 