### PR TITLE
blog: Show Etherpad controls

### DIFF
--- a/dolweb/blog/templates/etherpad-widget.html
+++ b/dolweb/blog/templates/etherpad-widget.html
@@ -1,1 +1,1 @@
-<iframe src="{{ BLOG_ETHERPAD_URL }}/p/{{ pad_id }}?showLineNumbers=false&showControls=false&showChat=true&alwaysShowChat=true" width="80%" height="600"></iframe>
+<iframe src="{{ BLOG_ETHERPAD_URL }}/p/{{ pad_id }}?showLineNumbers=false&showControls=true&showChat=true&alwaysShowChat=true" width="80%" height="600"></iframe>


### PR DESCRIPTION
While the formatting buttons don't work, having the controls is very      
handy as it makes it possible to clear colours and restore past   
revisions (in case something goes wrong).