### PR TITLE
Make development versions more visible (again)

### DIFF
--- a/dolweb/downloads/templates/downloads-index.html
+++ b/dolweb/downloads/templates/downloads-index.html
@@ -27,6 +27,38 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
     <h1>{% trans "Download" %}</h1>
 </div>
 
+<div id="download-dev">
+<h1>{% trans "Development versions" %}</h1>
+
+<div class="alert">{% blocktrans %}
+    <p>Development versions are released every time a developer makes a change to
+    Dolphin, several times every day! Using development versions enables you to
+    use the latest and greatest improvements to the project. They are however
+    less tested than stable versions of the emulator.</p>
+
+    <p>The development versions require the <a href="https://go.microsoft.com/fwlink/?LinkId=746572">64-bit Visual C++ redistributable for Visual Studio 2017</a>
+    to be installed.</p>
+{% endblocktrans %}</div>
+
+{% include "downloads-devrel.html" with builds=master_builds primclass='btn-info' %}
+
+<p><a class="btn" href="{% url 'downloads_list' "master" 1 %}">{% trans "View older versions »" %}</a></p>
+</div>
+
+<div style="text-align: center;">
+<script type="text/javascript"><!--
+google_ad_client = "ca-pub-8646203626363069";
+/* Downloads page ad (middle) */
+google_ad_slot = "2595840518";
+google_ad_width = 728;
+google_ad_height = 90;
+//-->
+</script>
+<script type="text/javascript"
+src="//pagead2.googlesyndication.com/pagead/show_ads.js">
+</script>
+</div>
+
 <div id="download-stable">
 <h1>{% trans "Stable versions" %}</h2>
 
@@ -56,38 +88,6 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
     {% endfor %}
     </tbody>
 </table>
-</div>
-
-<div style="text-align: center;">
-<script type="text/javascript"><!--
-google_ad_client = "ca-pub-8646203626363069";
-/* Downloads page ad (middle) */
-google_ad_slot = "2595840518";
-google_ad_width = 728;
-google_ad_height = 90;
-//-->
-</script>
-<script type="text/javascript"
-src="//pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
-</div>
-
-<div id="download-dev">
-<h1>{% trans "Development versions" %}</h1>
-
-<div class="alert">{% blocktrans %}
-    <p>Development versions are released every time a developer makes a change to
-    Dolphin, several times every day! Using development versions enables you to
-    use the latest and greatest improvements to the project. They are however
-    less tested than stable versions of the emulator.</p>
-
-    <p>The development versions require the <a href="https://go.microsoft.com/fwlink/?LinkId=746572">64-bit Visual C++ redistributable for Visual Studio 2017</a>
-    to be installed.</p>
-{% endblocktrans %}</div>
-
-{% include "downloads-devrel.html" with builds=master_builds primclass='btn-info' %}
-
-<p><a class="btn" href="{% url 'downloads_list' "master" 1 %}">{% trans "View older versions »" %}</a></p>
 </div>
 
 <div id="other-linux">

--- a/dolweb/homepage/views.py
+++ b/dolweb/homepage/views.py
@@ -22,6 +22,11 @@ def home(request):
     except IndexError:
         last_master = u"master"
 
+    # HACK: Since 6.0 is still a long way away, show dev versions on the
+    # homepage. We do it here instead of in the templates to avoid invalidating
+    # translations.
+    last_release = last_master
+
     home_articles = Entry.published.all()[:settings.HOMEPAGE_ARTICLES]
 
     return { 'featured_images': featured, 'last_release': last_release,


### PR DESCRIPTION
There have been many important new features (ubershaders for example) and many bug fixes since 5.0. Also, users on the forums keep reporting issues that could have been avoided just by using a newer version (notably Wii Remotes and System Menu stuff).
