### PR TITLE
Make copyright footer always show the current year

### DIFF
--- a/dolweb/templates/_base.html
+++ b/dolweb/templates/_base.html
@@ -147,8 +147,9 @@
 
         <footer>
         <p class="footer-text">
+            {% now 'Y' as year %}
             {% blocktrans %}
-            &copy; 2014 Dolphin Emulator Project -
+            &copy; {{ year }} Dolphin Emulator Project -
             <a href="{{ WEBSITE_GIT_URL }}">Website source code</a>
             {% endblocktrans %}
         </p>


### PR DESCRIPTION
The copyright text at the bottom of Dolphin's homepage has read "© 2014 Dolphin Emulator Project" for a while. I've made the text always display the current year, so that it may stay up to date as time goes on.

<img width="390" alt="screen shot 2018-10-25 at 14 01 41" src="https://user-images.githubusercontent.com/10043207/47520733-fdb7b280-d85e-11e8-90ee-9bda5c3603ea.png">
<img width="387" alt="screen shot 2018-10-25 at 14 01 48" src="https://user-images.githubusercontent.com/10043207/47520738-ff817600-d85e-11e8-90a9-61ebb9dd6559.png">

This issue was previously brought up here: https://bugs.dolphin-emu.org/issues/11033