### PR TITLE
Replace glyphicons with existing Unicode characters in bootstrap.css

### DIFF
--- a/dolweb/static/css/bootstrap.css
+++ b/dolweb/static/css/bootstrap.css
@@ -536,10 +536,10 @@ th {
   content: "\e078";
 }
 .glyphicon-chevron-left:before {
-  content: "\e079";
+  content: "«";
 }
 .glyphicon-chevron-right:before {
-  content: "\e080";
+  content: "»";
 }
 .glyphicon-plus-sign:before {
   content: "\e081";


### PR DESCRIPTION
This prevents the screenshots’ arrows from failing to render on modern browsers.