### PR TITLE
Add a RSS icon for the Atom feed on the blog

### DIFF
--- a/dolweb/blog/templates/zinnia/skeleton.html
+++ b/dolweb/blog/templates/zinnia/skeleton.html
@@ -15,6 +15,7 @@
     <div class="col-md-9">
 
         {% block breadcrumbs %}{% endblock breadcrumbs  %}
+        <a href="{% url 'zinnia:entry_feed' %}" class="rss-tag pull-right" title="{% trans "RSS feed of the latest articles" %}"><i class="icon-rss"></i></a>
         {% block slider %}{% endblock slider %}
 
         {% block content %}{% endblock %}


### PR DESCRIPTION
It was already present in the home page as well as on the series page, but not on the blog nor on specific entries.