### PR TITLE
update: Implement Updater API v1

### DIFF
--- a/dolweb/settings.py
+++ b/dolweb/settings.py
@@ -268,7 +268,7 @@ GIT_COMMIT_URL = "https://github.com/dolphin-emu/dolphin/commit/"
 GIT_PR_URL = "https://github.com/dolphin-emu/dolphin/pull/%s"
 WEBSITE_GIT_URL = "https://github.com/dolphin-emu/www"
 ISSUES_URL = "https://bugs.dolphin-emu.org/projects/emulator/issues"
-UPDATE_MANIFEST_URL = "https://update.dolphin-emu.org/manifest/%s/%s/%s.manifest"
+UPDATE_MANIFEST_URL = "https://update.dolphin-emu.org/manifest/%s/%s/%s/%s.manifest"
 
 # Used for i18n purposes: the language code is prepended to this default
 # hostname.

--- a/dolweb/update/urls.py
+++ b/dolweb/update/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
 
     # /update/check/dev/0000000...000
     # /update/check/beta/000000...000
-    url(r'^check/v(?P<updater_ver>\d+)/(?P<track>\w+)/(?P<version>[0-9a-f]{40})/?$',
+    url(r'^check/v(?P<updater_ver>\d+)/(?P<track>\w+)/(?P<version>[0-9a-f]{40})/?(?P<platform>\w+)?$',
         views.check,
         name='update_check'),
 ]


### PR DESCRIPTION
Changes:
- `` /update/v1/<track>/<hash>/<platform>`` - Now takes a platform parameter (Either ``macos``or ``win``)
- ``_check_on_auto_maintained_track`` and ``_check_on_manually_maintained_track`` now support handling different platforms

The API remains 100% backwards compatible to ``v0``.