### PR TITLE
Fix media-block having 0 height with only floating children

### DIFF
--- a/dolweb/static/css/dolphin.css
+++ b/dolweb/static/css/dolphin.css
@@ -584,6 +584,7 @@ div.draft-warning {
 .entry-content .media-block {
     margin-top: 2em;
     margin-bottom: 2em;
+    overflow: hidden;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
The media-block element has 0 height when it contains only floating children, has floating elements do not induce height on their parent. The result is text sitting to the right of the media when it shouldn't. Using overflow: hidden on it fixes this by establishing a new block formatting context, as explained here: https://www.w3.org/TR/CSS21/visuren.html#block-formatting