### PR TITLE
downloads: Link to Microsoft's "latest VC++ redistributable" page

### DIFF
--- a/dolweb/downloads/templates/downloads-index.html
+++ b/dolweb/downloads/templates/downloads-index.html
@@ -36,7 +36,7 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
     use the latest and greatest improvements to the project. They are however
     less tested than stable versions of the emulator.</p>
 
-    <p>The development versions require the <a href="https://go.microsoft.com/fwlink/?LinkId=746572">64-bit Visual C++ redistributable for Visual Studio 2017</a>
+    <p>The development versions require the <a href="https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads">64-bit Visual C++ redistributable for Visual Studio 2019</a>
     to be installed.</p>
 {% endblocktrans %}</div>
 


### PR DESCRIPTION
The 2019 redistributable is now required for development builds.
Rather than link to the exe directly and having to update the
website again when the link changes, I linked to Microsoft's
"latest supported Visual C++ downloads" page which will
stay updated.