### PR TITLE
Altered vs_redist text to be more visible

### DIFF
--- a/dolweb/downloads/templates/downloads-index.html
+++ b/dolweb/downloads/templates/downloads-index.html
@@ -30,15 +30,17 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 <div id="download-dev">
 <h1>{% trans "Development versions" %}</h1>
 
-<div class="alert">{% blocktrans %}
-    <p>Development versions are released every time a developer makes a change to
+<div class="alert alert-info">
+    <p>{% blocktrans %}Development versions are released every time a developer makes a change to
     Dolphin, several times every day! Using development versions enables you to
     use the latest and greatest improvements to the project. They are however
-    less tested than stable versions of the emulator.</p>
-{% endblocktrans %}</div>
+    less tested than stable versions of the emulator.{% endblocktrans %}</p>
+</div>
 
-<p style="font-size: 17px">{% blocktrans %}The development versions <b>require</b> the <a href="https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads">64-bit Visual C++ redistributable for Visual Studio 2019</a> to be installed.{% endblocktrans %}</p>
-
+<div class="alert alert-danger">
+    <p>{% blocktrans %}The development versions <b>require</b> the <a href="https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads">64-bit Visual C++ redistributable for Visual Studio 2019</a> to be installed.{% endblocktrans %}</p>
+</div>
+    
 {% include "downloads-devrel.html" with builds=master_builds primclass='btn-info' %}
 
 <p><a class="btn" href="{% url 'downloads_list' "master" 1 %}">{% trans "View older versions »" %}</a></p>

--- a/dolweb/downloads/templates/downloads-index.html
+++ b/dolweb/downloads/templates/downloads-index.html
@@ -35,10 +35,9 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
     Dolphin, several times every day! Using development versions enables you to
     use the latest and greatest improvements to the project. They are however
     less tested than stable versions of the emulator.</p>
-
-    <p>The development versions require the <a href="https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads">64-bit Visual C++ redistributable for Visual Studio 2019</a>
-    to be installed.</p>
 {% endblocktrans %}</div>
+
+<p style="font-size: 17px">{% blocktrans %}The development versions <b>require</b> the <a href="https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads">64-bit Visual C++ redistributable for Visual Studio 2019</a> to be installed.{% endblocktrans %}</p>
 
 {% include "downloads-devrel.html" with builds=master_builds primclass='btn-info' %}
 


### PR DESCRIPTION
This isn't as blatantly in your face as my previous PR, but there's a significant difference. This doesn't distract from the explanation of the development versions, and the position shows direct relevance to the downloads itself.

I feel this is satisfactory for all parties.

![pr](https://i.imgur.com/nsJLv1O.png)
