### PR TITLE
highlight active nav item

### DIFF
--- a/dolweb/blog/templatetags/blog_tags.py
+++ b/dolweb/blog/templatetags/blog_tags.py
@@ -7,6 +7,7 @@ register = Library()
 from bs4 import BeautifulSoup
 from django.conf import settings
 from django.template import defaultfilters
+from django.urls import reverse
 from dolweb.blog.models import BlogSeries
 
 @register.inclusion_tag('blog_chunk_series.html')
@@ -24,3 +25,10 @@ def cuthere_excerpt(content):
         return ''.join(map(str, reversed(cut_here.parent.find_previous_siblings())))
     except AttributeError:
         return defaultfilters.truncatewords(content, 100)
+
+
+@register.simple_tag
+def navactive(request, urls):
+    if request.path in ( reverse(url) for url in urls.split() ):
+        return "active"
+    return ""

--- a/dolweb/templates/_base.html
+++ b/dolweb/templates/_base.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% load language %}
 {% load static from staticfiles %}
+{% load blog_tags %}
 
 <!DOCTYPE html>
 
@@ -103,15 +104,33 @@
                 </div>
                 <div class="navbar-collapse collapse">
                     <ul class="nav navbar-nav pull-left">
-                        <li><a href="{% url 'downloads_index' %}">{% trans "Download" %}</a></li>
-                        <li><a href="{% url 'zinnia:entry_archive_index' %}">{% trans "Blog" %}</a></li>
-                        <li><a href="{% url 'media_all' %}">{% trans "Screenshots" %}</a></li>
-                        <li><a href="{% url 'docs_faq' %}">{% trans "FAQ" %}</a></li>
-                        <li><a href="{% url 'docs_guides_index' %}">{% trans "Guides" %}</a></li>
-                        <li><a href="{% url 'compat_index' %}">{% trans "Compatibility" %}</a></li>
-                        <li><a href="{{ FORUM_URL }}">{% trans "Forum" %}</a></li>
-                        <li><a href="{{ WIKI_URL }}">{% trans "Wiki" %}</a></li>
-                        <li><a href="{{ GIT_BROWSE_URL }}">{% trans "Code" %}</a></li>
+                        <li class="{% navactive request 'downloads_index' %}">
+                          <a href="{% url 'downloads_index' %}">{% trans "Download" %}</a>
+                        </li>
+                        <li class="{% navactive request 'zinnia:entry_archive_index' %}">
+                          <a href="{% url 'zinnia:entry_archive_index' %}">{% trans "Blog" %}</a>
+                        </li>
+                        <li class="{% navactive request 'media_all' %}">
+                          <a href="{% url 'media_all' %}">{% trans "Screenshots" %}</a>
+                        </li>
+                        <li class="{% navactive request 'docs_faq' %}">
+                          <a href="{% url 'docs_faq' %}">{% trans "FAQ" %}</a>
+                        </li>
+                        <li class="{% navactive request 'docs_guides_index' %}">
+                          <a href="{% url 'docs_guides_index' %}">{% trans "Guides" %}</a>
+                        </li>
+                        <li class="{% navactive request 'compat_index' %}">
+                          <a href="{% url 'compat_index' %}">{% trans "Compatibility" %}</a>
+                        </li>
+                        <li>
+                          <a href="{{ FORUM_URL }}">{% trans "Forum" %}</a>
+                        </li>
+                        <li>
+                          <a href="{{ WIKI_URL }}">{% trans "Wiki" %}</a>
+                        </li>
+                        <li>
+                          <a href="{{ GIT_BROWSE_URL }}">{% trans "Code" %}</a>
+                        </li>
                     </ul>
                     <ul class="nav navbar-nav pull-right">
                         <li class="dropdown">


### PR DESCRIPTION
addresses https://github.com/dolphin-emu/www/issues/62

i was cooped up and bored so i decided to knock this one out; stole the pattern from https://www.turnkeylinux.org/blog/django-navbar

lookin good locally; couple examples:
download page
<img width="947" alt="Screen Shot 2020-03-22 at 11 53 52" src="https://user-images.githubusercontent.com/5599894/77253877-dc195100-6c33-11ea-9d99-911bae3dbe1f.png">

guide page
<img width="947" alt="Screen Shot 2020-03-22 at 11 54 09" src="https://user-images.githubusercontent.com/5599894/77253878-de7bab00-6c33-11ea-9107-df98fee99d9a.png">
