### PR TITLE
Adjusted Styles of Beta and Dev Downloads

### DIFF
--- a/dolweb/downloads/templates/downloads-index.html
+++ b/dolweb/downloads/templates/downloads-index.html
@@ -29,16 +29,17 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 
 <div id="download-beta">
 <h1>{% trans "Beta versions" %}</h1>
-
-<div class="alert">{% blocktrans %}
+    
+<div class="alert alert-info">{% blocktrans %}
     <p>Beta versions are released every month, usually accompanied by a
     <em>Progress Report</em> article. They are a good balance between the Dolphin
     <a href="#download-dev">development versions</a> and the
     <a href="#download-stable">stable versions</a>.</p>
-
-    <div class="alert alert-info">The beta versions require the <a href="https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads">64-bit Visual C++ redistributable for Visual Studio 2019</a>
-    to be installed.</div>
 {% endblocktrans %}</div>
+
+<div class="alert alert-danger">
+    <p>{% blocktrans %}The beta versions <b>require</b> the <a href="https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads">64-bit Visual C++ redistributable for Visual Studio 2019</a> to be installed.{% endblocktrans %}</p>
+</div>
 
 {% include "downloads-devrel.html" with builds=beta_builds primclass='btn-info' %}
 
@@ -46,16 +47,17 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 
 <div id="download-dev">
 <h1>{% trans "Development versions" %}</h1>
-
-<div class="alert">{% blocktrans %}
-    <p>Development versions are released every time a developer makes a change to
+    
+<div class="alert alert-info">
+    <p>{% blocktrans %}Development versions are released every time a developer makes a change to
     Dolphin, several times every day! Using development versions enables you to
     use the latest and greatest improvements to the project. They are however
-    less tested than stable versions of the emulator.</p>
+    less tested than stable versions of the emulator.{% endblocktrans %}</p>
+</div>
 
-    <div class="alert alert-info">The development versions require the <a href="https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads">64-bit Visual C++ redistributable for Visual Studio 2019</a>
-    to be installed.</div>
-{% endblocktrans %}</div>
+<div class="alert alert-danger">
+    <p>{% blocktrans %}The development versions <b>require</b> the <a href="https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads">64-bit Visual C++ redistributable for Visual Studio 2019</a> to be installed.{% endblocktrans %}</p>
+</div>
 
 {% include "downloads-devrel.html" with builds=master_builds primclass='btn-info' %}
 


### PR DESCRIPTION
Adjusted the styles to be more consistent and clear as discussed in https://github.com/dolphin-emu/www/pull/112

Previews:

![image](https://user-images.githubusercontent.com/4237834/80380558-a81af680-8897-11ea-8d6d-c9c713b9cec9.png)


Old for comparison:
https://user-images.githubusercontent.com/4237834/80380661-c5e85b80-8897-11ea-8229-69d8dd25cbd9.png
