### PR TITLE
Add download URL to buildlist for bisect tools.

### DIFF
--- a/dolweb/downloads/views.py
+++ b/dolweb/downloads/views.py
@@ -54,11 +54,12 @@ def branches(request):
 @cache_control(max_age=15)
 def buildlist(request):
     """Displays a list of builds from buildbot for the bisect tool"""
-    master_builds = DevVersion.objects.filter(branch='master').order_by('-date')
-    shortrev_list = []
+    master_builds = Artifact.objects.filter(branch='master').order_by('-date')
+    builds_list = []
     for build in master_builds:
-        shortrev_list.append(build.shortrev)
-    return JsonResponse(shortrev_list, safe=False)
+        rev_info = [build.shortrev,  build.url]
+        builds_list.append(rev_info)
+    return JsonResponse(builds_list, safe=False)
 
 @vary_on_headers('User-Agent')
 @render_to('downloads-view-devrel.html')


### PR DESCRIPTION
The [DolphinBisectTool](https://github.com/Helios747/DolphinBisectTool/) has been [broken](https://github.com/Helios747/DolphinBisectTool/issues/27) since the previous download URL format was changed. Right now it's not easy to grab the download url, but since there's an endpoint which was specifically implemented to give the bisecttool useful information, I suggest adding the download URL with each revision, as @Helios747 suggested in January. Once this is done, I (or someone else) can fix the BisectTool, and new ones may be created with ease.
