### PR TITLE
Clarify that Visual C++ redist is Windows only

### DIFF
--- a/dolweb/downloads/templates/downloads-index.html
+++ b/dolweb/downloads/templates/downloads-index.html
@@ -38,7 +38,7 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 {% endblocktrans %}</div>
 
 <div class="alert alert-danger">
-    <p>{% blocktrans %}The beta versions <b>require</b> the <a href="https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads">64-bit Visual C++ redistributable for Visual Studio 2019</a> to be installed.{% endblocktrans %}</p>
+    <p>{% blocktrans %}The Windows beta versions <b>require</b> the <a href="https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads">64-bit Visual C++ redistributable for Visual Studio 2019</a> to be installed.{% endblocktrans %}</p>
 </div>
 
 {% include "downloads-devrel.html" with builds=beta_builds primclass='btn-info' %}
@@ -56,7 +56,7 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 </div>
 
 <div class="alert alert-danger">
-    <p>{% blocktrans %}The development versions <b>require</b> the <a href="https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads">64-bit Visual C++ redistributable for Visual Studio 2019</a> to be installed.{% endblocktrans %}</p>
+    <p>{% blocktrans %}The Windows development versions <b>require</b> the <a href="https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads">64-bit Visual C++ redistributable for Visual Studio 2019</a> to be installed.{% endblocktrans %}</p>
 </div>
 
 {% include "downloads-devrel.html" with builds=master_builds primclass='btn-info' %}


### PR DESCRIPTION
This statement appears just above the windows/macos/android downloads. While right on point for windows users, the previous statement was confusing some android users into trying to download and install the redistributable even though it's not needed (and in fact impossible to install) on their platform.