### PR TITLE
update: Fix check URLs for macos-universal returning 404

### DIFF
--- a/dolweb/update/urls.py
+++ b/dolweb/update/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
 
     # /update/check/dev/0000000...000
     # /update/check/beta/000000...000
-    url(r'^check/v(?P<updater_ver>\d+)/(?P<track>\w+)/(?P<version>[0-9a-f]{40})/?(?P<platform>\w+)?$',
+    url(r'^check/v(?P<updater_ver>\d+)/(?P<track>\w+)/(?P<version>[0-9a-f]{40})/?(?P<platform>[A-Za-z0-9-_]+)?$',
         views.check,
         name='update_check'),
 ]

--- a/dolweb/update/views.py
+++ b/dolweb/update/views.py
@@ -109,7 +109,7 @@ def check(request, updater_ver, track, version, platform):
     if updater_ver == "0":
         platform = "win"
     else:
-        if platform != "win" and platform != "macos":
+        if platform != "win" and platform != "macos" and platform != "macos-universal":
             return _error_response(400,
                                    "Unsupported platform %r" % platform)
 


### PR DESCRIPTION
The regex to extract the platform in `/update/check` uses `\w`, which does not match dashes. This causes all `macos-universal` update checks to return 404 Not Found. So, I replaced `\w` with something equivalent that also matches dashes.

In addition, I added `macos-universal` to the supported platforms check.

This PR is completely untested, because I have no idea how to spin up an instance of this. I'm pretty sure the changes are correct, though...