### PR TITLE
downloads: fix inconsistent order for macOS download links

### DIFF
--- a/dolweb/downloads/templatetags/artifacts.py
+++ b/dolweb/downloads/templatetags/artifacts.py
@@ -11,10 +11,12 @@ def artifact_sort(artifacts):
     matchers = (
         ('Windows', 0x8000),
         ('macOS', 0x4000),
+        ('Mac OS X', 0x3ff0), # for historical builds
         ('Android', 0x2000),
         ('Ubuntu', 0x1000),
         ('x64', 0x8),
         ('x86', 0x4),
+        ('Universal', 0x2),
     )
     def key(artifact):
         k = 0


### PR DESCRIPTION
Sort ARM/Intel Universal builds before Intel builds, and also change historical Mac OS X builds to have the same position relative to other operating systems as modern macOS builds do.

