### PR TITLE
Fix title and description in Discord previews (and possibly other sites)

### DIFF
--- a/dolweb/templates/_base.html
+++ b/dolweb/templates/_base.html
@@ -12,9 +12,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="description" content="{% block "metadescr" %}{% endblock %}">
 
-        <meta property="og:title" content="Dolphin Emulator" />
-        <meta property="og:type" content="product" />
-        <meta property="og:image" content="https://sphotos-a.ak.fbcdn.net/hphotos-ak-prn1/73367_365599063538538_1010982140_n.png" />
+        <meta property="og:type" content="article" />
         <meta property="og:site_name" content="Dolphin Emulator" />
         <meta property="fb:admins" content="1064682820" />
 


### PR DESCRIPTION
og:title was hardcoded to "Dolphin Emulator" instead of being set to
the article title or the page name.

og:type was set to an invalid value.

og:image is a dead link, and it was pointing to an image hosted on
Facebook's CDN for some reason (???). Just remove it and let crawlers
figure out what image to show (usually the article banner).

This should fix article previews showing
"Dolphin Emulator - Dolphin Emulator" with no image in Discord.