### PR TITLE
update: migrate macos users to macos-universal

### DIFF
--- a/dolweb/update/views.py
+++ b/dolweb/update/views.py
@@ -116,6 +116,10 @@ def check(request, updater_ver, track, version, platform):
     old_platform = platform
     new_platform = platform
 
+    # Migrate macOS (Intel) users to universal macOS builds.
+    if old_platform == "macos":
+        new_platform = "macos-universal"
+
     if track in settings.AUTO_MAINTAINED_UPDATE_TRACKS:
         return _check_on_auto_maintained_track(request, track, version, old_platform, new_platform)
     else:


### PR DESCRIPTION
This makes sure existing users will not be left behind on the Intel
macOS builds after the old macOS VM is shut down.

An alternative approach would have been to add some special logic
in Dolphin's auto-update code to request a macos-universal target
manifest on macos builds (instead of defaulting to the current
platform). The downside to this approach is that users who are
on older builds would have to update twice: the first time to a
version of Dolphin that has the aforementioned special logic, and
a second time to actually switch to a macos-universal build.

I'm not very familiar with the update code so please review carefully :)