### PR TITLE
Upgrade to Bootstrap 5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ local_settings.py
 /media/
 *.mo
 venv
+bin
+lib
+lib64
+.idea
+share
+pyvenv.cfg

--- a/dolweb/blog/templates/blog_sidebar.html
+++ b/dolweb/blog/templates/blog_sidebar.html
@@ -1,39 +1,44 @@
 {% load i18n zinnia blog_tags %}
 
-<div style="margin-bottom: 1em">
-    <form method="get" action="{% url 'zinnia:entry_search' %}" role="search">
-        <div class="input-group">
-            <input type="text" placeholder="{% trans "Search articles" %}" name="pattern" class="form-control" />
-            <span class="input-group-btn">
-                <button type="submit" class="btn">
-                    <i class="icon-search"></i>
+<div class="row row-cols-1">
+    <div class="col">
+        <form method="get" action="{% url 'zinnia:entry_search' %}" role="search">
+            <div class="input-group mb-3">
+                <input type="text" placeholder="{% trans "Search articles" %}" name="pattern" class="form-control" />
+                <button type="submit" class="btn btn-outline-secondary">
+                    <i class="bi bi-search"></i>
                 </button>
-            </span>
+            </div>
+        </form>
+    </div>
+
+    <div class="col">
+        <div class="text-center">
+            <script type="text/javascript"><!--
+            google_ad_client = "ca-pub-8646203626363069";
+            /* Dolphin Blog Sidebar Ad */
+            google_ad_slot = "9795528512";
+            google_ad_width = 200;
+            google_ad_height = 200;
+            //-->
+            </script>
+            <script type="text/javascript"
+                    src="//pagead2.googlesyndication.com/pagead/show_ads.js">
+            </script>
         </div>
-    </form>
-</div>
+    </div>
 
-<div class="well text-center">
-    <script type="text/javascript"><!--
-    google_ad_client = "ca-pub-8646203626363069";
-    /* Dolphin Blog Sidebar Ad */
-    google_ad_slot = "9795528512";
-    google_ad_width = 200;
-    google_ad_height = 200;
-    //-->
-    </script>
-    <script type="text/javascript"
-    src="//pagead2.googlesyndication.com/pagead/show_ads.js">
-    </script>
-</div>
-
-<div class="well">
-    <h4>{% trans "Blog tags" %}</h4>
-    {% get_tag_cloud %}
-</div>
-
-<div class="well">
-    <h4>{% trans "Blog series" %}</h4>
-    {% get_recent_blog_series 3 %}
-    <p class="seemore"><a href="{% url 'dolweb_blog_series_index' %}">{% trans "See all" %} »</a></p>
+    <div class="col">
+        <div class="card">
+            <div class="card-body">
+                <h5 class="card-title">{% trans "Blog tags" %}</h5>
+                {% get_tag_cloud %}
+            </div>
+            <div class="card-body">
+                <h5 class="card-title">{% trans "Blog series" %}</h5>
+                {% get_recent_blog_series 3 %}
+                <div class="float-end"><a href="{% url 'dolweb_blog_series_index' %}">{% trans "See all" %} »</a></div>
+            </div>
+        </div>
+    </div>
 </div>

--- a/dolweb/blog/templates/series-index.html
+++ b/dolweb/blog/templates/series-index.html
@@ -7,33 +7,36 @@
 
 {% block content %}
 
-{% for series in all_series %}
+    {% for series in all_series %}
 
-<div class="well clearfix series">
-  {% if series.image %}
-    {% thumbnail series.image "120x120" crop="center" format="PNG" as im %}
-    <img src="{{ im.url }}" alt="Series illustration" class="pull-left thumbnail" width="{{ im.width }}" height="{{ im.height }}" />
-    {% endthumbnail %}
-  {% endif %}
-  <div class="innerdiv">
-  {# <h2 id="serie-{{ serie.pk }}"><a href="{% url 'dolweb.blog.views.serie_view' uid=serie.pk %}">{{ serie.name }}</a> #}
-  <h2 id="series-{{ series.pk }}">{{ series.name }}
-  <small>{% blocktrans count count=series.entries.count %}
-    {{ count }} entry
-  {% plural %}
-    {{ count }} entries
-  {% endblocktrans %}</small></h2>
-  <p>{% trans "RSS feed:" %} <a href="{% url 'dolweb_blog_series_feed' pk=series.pk %}" class="rss-tag"><i class="icon-rss"></i></a></p>
-  <ol>
-  {% for entry in series.entries_reversed %}
-  <li><a href="{{ entry.get_absolute_url }}">{{ entry.title }}</a></li>
-  {% endfor %}
-  </ol>
-  </div>
-</div>
+        <div class="mb-5 series">
+            {% if series.image %}
+                {% thumbnail series.image "120x120" crop="center" format="PNG" as im %}
+                    <img src="{{ im.url }}" alt="Series illustration" class="pull-left thumbnail" width="{{ im.width }}" height="{{ im.height }}" />
+                {% endthumbnail %}
+            {% endif %}
+            <div class="innerdiv">
+                {# <h2 id="serie-{{ serie.pk }}"><a href="{% url 'dolweb.blog.views.serie_view' uid=serie.pk %}">{{ serie.name }}</a> #}
+                <h2 id="series-{{ series.pk }}">{{ series.name }}
+                    <small class="text-muted">{% blocktrans count count=series.entries.count %}
+                        {{ count }} entry
+                    {% plural %}
+                        {{ count }} entries
+                    {% endblocktrans %}</small>
+                </h2>
+                <p>
+                    {% trans "RSS feed:" %} <a href="{% url 'dolweb_blog_series_feed' pk=series.pk %}" class="rss-tag"><i class="bi bi-rss" role="button" aria-label="RSS"></i></a>
+                </p>
+                <ol>
+                    {% for entry in series.entries_reversed %}
+                        <li><a href="{{ entry.get_absolute_url }}">{{ entry.title }}</a></li>
+                    {% endfor %}
+                </ol>
+            </div>
+        </div>
 
-{% empty %}
-<p>{% trans "No blog series yet." %}</p>
-{% endfor %}
+    {% empty %}
+        <p>{% trans "No blog series yet." %}</p>
+    {% endfor %}
 
 {% endblock %}

--- a/dolweb/blog/templates/zinnia/_entry_detail_base.html
+++ b/dolweb/blog/templates/zinnia/_entry_detail_base.html
@@ -1,98 +1,99 @@
 {% load comments i18n thumbnail %}
-<div id="entry-{{ object.pk }}" class="hentry{% if object.featured %} featured{% endif %}">
-  {% if object.draft %}
-  <div class="draft-warning blink">
-    This article is a draft. Avoid widely sharing this link.
-  </div>
-  {% endif %}
-  {% block entry-header %}
-  <div class="entry-header">
-    {% block entry-title %}
-    <h2 class="entry-title">
-      <a href="{{ object.get_absolute_url }}" title="{{ object.title }}" rel="bookmark">
-        {{ object.title }}
-      </a>
-    </h2>
-    {% endblock %}
-    {% block entry-info %}
-    <div class="entry-meta-line">
-    <p class="entry-info">
-      {% with authors=object.authors.all %}
-      {% if authors|length %}
-      {% trans "Written by" %}
-      {% for author in authors %}
-      <span class="vcard author">
+<div id="entry-{{ object.pk }}" class="card{% if object.featured %} featured{% endif %} mb-3">
+    <div class="card-body">
+        {% block entry-header %}
+            <div class="entry-header">
+                {% block entry-title %}
+                    <h4 class="card-title">
+                        <a href="{{ object.get_absolute_url }}" title="{{ object.title }}" rel="bookmark">
+                            {{ object.title }}
+                        </a>
+                    </h4>
+                {% endblock %}
+                {% if object.draft %}
+                    <div class="draft-warning blink">
+                        This article is a draft. Avoid widely sharing this link.
+                    </div>
+                {% endif %}
+                {% block entry-info %}
+                    <div class="entry-meta-line">
+                    <p class="entry-info">
+                        {% with authors=object.authors.all %}
+                            {% if authors|length %}
+                                {% trans "Written by" %}
+                                {% for author in authors %}
+                                    <span class="vcard author">
         <a href="{{ author.get_absolute_url }}" class="fn url{% if not author.get_full_name %} nickname{% endif %}" rel="author"
            title="{% blocktrans %}Show all {{ author }}'s entries{% endblocktrans %}">{{ author }}</a></span>{% if not forloop.last %}, {% endif %}
-      {% endfor %}
-      {% trans "on" %}
-      {% else %}
-      {% trans "Written on" %}
-      {% endif %}
-      {% endwith %}
-      <abbr class="published" title="{{ object.publication_date|date:"c" }}">{{ object.publication_date|date:"DATE_FORMAT" }}</abbr>
-    </p>
-    {% endblock %}
-    {% block entry-last-update %}
-    <p class="entry-last-update">
-      / {% trans "Last update on" %} <abbr class="updated" title="{{ object.last_update|date:"c" }}">{{ object.last_update|date:"DATE_FORMAT" }}</abbr>
-    / <a href="{{ object.short_url }}"
-       title="{% blocktrans with object=object.title %}Short URL to {{ object }}{% endblocktrans %}"
-       rel="shortlink">{% trans "Short link" %}</a>
-    {% if object.forum_thread %}/ <i class="icon-comments"></i> <a href="{{ object.forum_thread.get_absolute_url }}" title="{% trans "Visit forum thread for this article" %}">{% trans "Forum thread" %}</a>{% endif %}
-    </p>
-    </div>
-    {% endblock %}
-  </div>
-  {% endblock %}
+                                {% endfor %}
+                                {% trans "on" %}
+                            {% else %}
+                                {% trans "Written on" %}
+                            {% endif %}
+                        {% endwith %}
+                        <abbr class="published" title="{{ object.publication_date|date:"c" }}">{{ object.publication_date|date:"DATE_FORMAT" }}</abbr>
+                    </p>
+                {% endblock %}
+                {% block entry-last-update %}
+                    <p class="entry-last-update">
+                        / {% trans "Last update on" %} <abbr class="updated" title="{{ object.last_update|date:"c" }}">{{ object.last_update|date:"DATE_FORMAT" }}</abbr>
+                        / <a href="{{ object.short_url }}"
+                             title="{% blocktrans with object=object.title %}Short URL to {{ object }}{% endblocktrans %}"
+                             rel="shortlink">{% trans "Short link" %}</a>
+                        {% if object.forum_thread %}/ <i class="bi bi-chat-fill"></i> <a href="{{ object.forum_thread.get_absolute_url }}" title="{% trans "Visit forum thread for this article" %}">{% trans "Forum thread" %}</a>{% endif %}
+                    </p>
+                    </div>
+                {% endblock %}
+            </div>
+        {% endblock %}
 
-  {% block entry-body %}
-  <div class="entry-body">
-    {% block entry-content %}
-    <div class="entry-content">
-      {{ object_content }}
+        {% block entry-body %}
+            <div class="entry-body">
+                {% block entry-content %}
+                    <div class="entry-content">
+                        {{ object_content }}
 
-    {% block continue-reading %}
-    {% if continue_reading %}
-    <p class="continue-reading">
-      <a href="{{ object.get_absolute_url }}"
-         title="{% blocktrans with object=object.title %}Continue reading {{ object }}{% endblocktrans %}"
-         rel="bookmark">
-        {% trans "Continue reading" %}
-      </a>
-    </p>
-    {% endif %}
-    {% endblock %}
+                        {% block continue-reading %}
+                            {% if continue_reading %}
+                                <p class="continue-reading">
+                                    <a href="{{ object.get_absolute_url }}"
+                                       title="{% blocktrans with object=object.title %}Continue reading {{ object }}{% endblocktrans %}"
+                                       rel="bookmark">
+                                        {% trans "Continue reading" %}
+                                    </a>
+                                </p>
+                            {% endif %}
+                        {% endblock %}
 
-    </div>
-    {% endblock %}
-    {% if object.forum_thread %}
-    <p><i class="icon-comments"></i> {% blocktrans with url=object.forum_thread.get_absolute_url %}You can continue the discussion in the <a href="{{url}}" title="Visit forum thread for this article">forum thread</a> of this article.{% endblocktrans %}</p>{% endif %}
-  </div>
-  {% endblock %}
+                    </div>
+                {% endblock %}
+                {% if object.forum_thread %}
+                    <p><i class="bi bi-chat-fill"></i> {% blocktrans with url=object.forum_thread.get_absolute_url %}You can continue the discussion in the <a href="{{url}}" title="Visit forum thread for this article">forum thread</a> of this article.{% endblocktrans %}</p>{% endif %}
+            </div>
+        {% endblock %}
 
-  {% block entry-footer %}
-  <div class="entry-footer row">
-    <div class="col-md-6">
-    {% block entry-series %}
-    {% if object.within_series %}
-    <h4>{% trans "Blog series" %}</h4>
-    {% url 'dolweb_blog_series' uid=object.within_series.pk as series_url %}
-    <p>{% blocktrans with nth=object.series_index url=series_url series=object.within_series %}This article is number {{ nth }} within the blog series
-    <a href="{{ url }}"><em>{{ series }}</em></a>.{% endblocktrans %} {# </p> #}
-    {% with previous=object.previous_entry_in_series next=object.next_entry_in_series %}
-    {% if previous or next %}
-    {# <p> #}
-      {% if previous %}<a href="{{ previous.get_absolute_url }}">{% trans "‹ Previous article in series" %}</a>{% endif %}
-      {% if previous and next %}/{% endif %}
-      {% if next %}<a href="{{ next.get_absolute_url }}">{% trans "Next article in series ›" %}</a>{% endif %}
-    </p>
-    {% endif %}
-    {% endwith %}
-    {% endif %}
-    {% endblock %}
-    {% block entry-comments %}
-    {% comment %}
+        {% block entry-footer %}
+            <div class="entry-footer row">
+                <div class="col-md-6">
+                    {% block entry-series %}
+                        {% if object.within_series %}
+                            <h4>{% trans "Blog series" %}</h4>
+                            {% url 'dolweb_blog_series' uid=object.within_series.pk as series_url %}
+                            <p>{% blocktrans with nth=object.series_index url=series_url series=object.within_series %}This article is number {{ nth }} within the blog series
+                                <a href="{{ url }}"><em>{{ series }}</em></a>.{% endblocktrans %} {# </p> #}
+                                {% with previous=object.previous_entry_in_series next=object.next_entry_in_series %}
+                                    {% if previous or next %}
+                                        {# <p> #}
+                                        {% if previous %}<a href="{{ previous.get_absolute_url }}">{% trans "‹ Previous article in series" %}</a>{% endif %}
+                                        {% if previous and next %}/{% endif %}
+                                        {% if next %}<a href="{{ next.get_absolute_url }}">{% trans "Next article in series ›" %}</a>{% endif %}
+                                        </p>
+                                    {% endif %}
+                                {% endwith %}
+                        {% endif %}
+                    {% endblock %}
+                    {% block entry-comments %}
+                        {% comment %}
     <p class="entry-comments">
       <strong>{% trans "Discussions" %}</strong> :
       {% with comment_count=object.comment_count %}
@@ -129,36 +130,37 @@
       {% endwith %}
     </p>
     {% endcomment %}
-    {% endblock %}
-    </div>
+                    {% endblock %}
+                </div>
 
-    {% block entry-tags %}
-    <div class="entry-tags col-md-3">
-      <h4>{% trans "Tags" %}</h4>
-      <ul class="tag-cloud">
-      {% for tag in object.tags_list %}
-      <li><a href="{% url 'zinnia:tag_detail' tag %}"
-         title="{% blocktrans %}Show all entries tagged by {{ tag }}{% endblocktrans %}"
-         rel="tag">{{ tag }}</a></li>
-      {% empty %}
-      <span class="empty">{% trans "No tags" %}</span>
-      {% endfor %}
-      </ul>
+                {% block entry-tags %}
+                    <div class="entry-tags col-md-3">
+                        <h4>{% trans "Tags" %}</h4>
+                        <ul class="tag-cloud">
+                            {% for tag in object.tags_list %}
+                                <li><a href="{% url 'zinnia:tag_detail' tag %}"
+                                       title="{% blocktrans %}Show all entries tagged by {{ tag }}{% endblocktrans %}"
+                                       rel="tag">{{ tag }}</a></li>
+                            {% empty %}
+                                <span class="empty">{% trans "No tags" %}</span>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                {% endblock %}
+                {% block entry-categories %}
+                    <div class="entry-categories col-md-3">
+                        <h4>{% trans "Categories" %}</h4>
+                        {% with categories=object.categories.all %}
+                            {% for category in categories %}
+                                <a href="{{ category.get_absolute_url }}"
+                                   title="{% blocktrans %}Show all entries in {{ category }}{% endblocktrans %}"
+                                   rel="tag category">{{ category }}</a>{% if not forloop.last %}, {% endif %}
+                            {% empty %}
+                                <span class="empty">{% trans "No categories" %}</span>
+                            {% endfor %}{% endwith %}
+                    </div>
+                {% endblock %}
+            </div>
+        {% endblock %}
     </div>
-    {% endblock %}
-    {% block entry-categories %}
-    <div class="entry-categories col-md-3">
-      <h4>{% trans "Categories" %}</h4>
-      {% with categories=object.categories.all %}
-      {% for category in categories %}
-      <a href="{{ category.get_absolute_url }}"
-         title="{% blocktrans %}Show all entries in {{ category }}{% endblocktrans %}"
-         rel="tag category">{{ category }}</a>{% if not forloop.last %}, {% endif %}
-      {% empty %}
-      <span class="empty">{% trans "No categories" %}</span>
-      {% endfor %}{% endwith %}
-    </div>
-    {% endblock %}
-  </div>
-  {% endblock %}
 </div>

--- a/dolweb/blog/templates/zinnia/skeleton.html
+++ b/dolweb/blog/templates/zinnia/skeleton.html
@@ -8,17 +8,19 @@
 
 {% block "body" %}
 
-<div class="row">
-    <div class="col-md-9 col-md-push-3" style="margin-top: 1em">
+<div class="row mt-5">
+    <div class="col-md-9 order-md-2">
 
         {% block breadcrumbs %}{% endblock breadcrumbs  %}
-        <a href="{% url 'zinnia:entry_feed' %}" class="rss-tag pull-right" title="{% trans "RSS feed of the latest articles" %}"><i class="icon-rss"></i></a>
+        <div class="mb-3 mt-3">
+            <a href="{% url 'zinnia:entry_feed' %}" class="rss-tag" title="{% trans "RSS feed of the latest articles" %}"><i class="bi bi-rss" role="button" aria-label="RSS"></i></a>
+        </div>
         {% block slider %}{% endblock slider %}
 
         {% block content %}{% endblock %}
 
     </div>
-    <div class="col-md-3 col-md-pull-9" style="margin-top: 1em">
+    <div class="col-md-3">
         {% include "blog_sidebar.html" %}
     </div>
 </div>

--- a/dolweb/blog/templates/zinnia/tags/breadcrumbs.html
+++ b/dolweb/blog/templates/zinnia/tags/breadcrumbs.html
@@ -1,11 +1,13 @@
-<ol class="breadcrumb">
-  {% for crumb in breadcrumbs %}
-  <li>
-    {% if crumb.url %}
-    <a href="{{ crumb.url }}" title="{{ crumb.name }}">{{ crumb.name }}</a>
-    {% else %}
-    {{ crumb.name }}
-    {% endif %}
-  </li>
-  {% endfor %}
-</ol>
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        {% for crumb in breadcrumbs %}
+            <li class="breadcrumb-item{% if not crumb.url %} active{% endif %}"{% if not crumb.url %} aria-current="page"{% endif %}>
+                {% if crumb.url %}
+                    <a href="{{ crumb.url }}" title="{{ crumb.name }}">{{ crumb.name }}</a>
+                {% else %}
+                    {{ crumb.name }}
+                {% endif %}
+            </li>
+        {% endfor %}
+    </ol>
+</nav>

--- a/dolweb/blog/templates/zinnia/tags/search_form.html
+++ b/dolweb/blog/templates/zinnia/tags/search_form.html
@@ -1,18 +1,16 @@
 {% load i18n %}
 {% load static from staticfiles %}
 
-<form method="get" action="{% url 'zinnia:entry_search' %}" role="search">
-    <div class="input-group">
+<form method="get" action="{% url 'zinnia:entry_search' %}" role="search" class="d-none d-md-block">
+    <div class="input-group mb-3">
         <input type="text" placeholder="{% trans "Search articles" %}" name="pattern" class="form-control" />
-        <span class="input-group-btn">
-            <button type="submit" class="btn">
-                <i class="icon-search"></i>
-            </button>
-        </span>
+        <button type="submit" class="btn btn-outline-secondary">
+            <i class="bi bi-search"></i>
+        </button>
     </div>
 </form>
 
-<p class="alert alert-info" style="margin-top: 1em">
-<img src="{% static "zinnia/img/help.png" %}" alt="?" class="help" width="14" height="14" />
-{% trans "You can use - to exclude words or phrases, &quot;double quotes&quot; for exact phrases and the AND/OR boolean operators combined with parenthesis for complex queries." %}
+<p class="alert alert-info mt-3">
+    <i class="bi bi-question-circle"></i>
+    {% trans "You can use - to exclude words or phrases, &quot;double quotes&quot; for exact phrases and the AND/OR boolean operators combined with parenthesis for complex queries." %}
 </p>

--- a/dolweb/compat/admin.py
+++ b/dolweb/compat/admin.py
@@ -2,9 +2,24 @@
 # SPDX-License-Identifier: MIT
 
 from django.contrib import admin
-from dolweb.compat.models import Page
+from dolweb.compat.models import Page, Revision, Category, CategoryLink
+
 
 class PageAdmin(admin.ModelAdmin):
     list_display = ('title', 'namespace')
     ordering = ('namespace', 'title_url')
 admin.site.register(Page, PageAdmin)
+
+class RevisionAdmin(admin.ModelAdmin):
+    list_display = ('page', 'text', 'timestamp')
+    ordering = ('timestamp',)
+admin.site.register(Revision, RevisionAdmin)
+
+class CategoryAdmin(admin.ModelAdmin):
+    list_display = ('title',)
+    ordering = ('id',)
+admin.site.register(Category, CategoryAdmin)
+
+class CategoryLinkAdmin(admin.ModelAdmin):
+    list_display = ('page', 'cat')
+admin.site.register(CategoryLink, CategoryLinkAdmin)

--- a/dolweb/compat/models.py
+++ b/dolweb/compat/models.py
@@ -49,7 +49,7 @@ class Revision(models.Model):
     timestamp = models.CharField(db_column='rev_timestamp', max_length=14)
 
     def __str__(self):
-        return '%s for %s' % (self.timestamp_raw, self.page)
+        return '%s for %s' % (self.timestamp, self.page)
 
     class Meta:
         db_table = 'revision'

--- a/dolweb/compat/templates/compat-list-pagi.html
+++ b/dolweb/compat/templates/compat-list-pagi.html
@@ -1,12 +1,12 @@
 {% load compat %}
-<div class="text-center">
-<ul class="pagination">
-{% for p in pages %}
-    {% if p == page %}
-    <li class="active"><a href="#">{{ p }}</a></li>
-    {% else %}
-    <li><a href="{% compat_url p filter_by %}">{{ p }}</a></li>
-    {% endif %}
-{% endfor %}
-</ul>
-</div>
+<nav class="mt-3 mb-3">
+    <ul class="pagination justify-content-center flex-wrap">
+    {% for p in pages %}
+        {% if p == page %}
+        <li class="page-item active"><a class="page-link" href="#">{{ p }}</a></li>
+        {% else %}
+        <li class="page-item"><a class="page-link" href="{% compat_url p filter_by %}">{{ p }}</a></li>
+        {% endif %}
+    {% endfor %}
+    </ul>
+</nav>

--- a/dolweb/compat/templates/compat-list.html
+++ b/dolweb/compat/templates/compat-list.html
@@ -15,56 +15,109 @@
 {% endblock %}
 
 {% block "body" %}
+<div class="card mt-5 p-3">
+    <div class="row">
+        <div class="col-md-9 col-12">
+            <div class="ratings-expl">
+            <h3>{% trans "How to read the ratings" %}</h3>
 
-<div class="col-row">
-<div class="row">
-    <div class="col-md-9 well col">
-        <div class="ratings-expl">
-        <h3>{% trans "How to read the ratings" %}</h3>
+                <ul class="mt-3 mb-0 px-0">
+                    <li>
+                        <div class="row">
+                            <div class="col-auto">
+                                {% trans "Perfect" as perfect_text %}
+                                {% include "compat-rating-responsive.html" with rating="5" rating_text=perfect_text %}
+                            </div>
+                            <div class="col">
+                                {% trans "<strong>Perfect</strong>: No issues at all!" %}
+                            </div>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="row">
+                            <div class="col-auto">
+                                {% trans "Playable" as playable_text %}
+                                {% include "compat-rating-responsive.html" with rating="4" rating_text=playable_text %}
+                            </div>
+                            <div class="col">
+                                {% trans "<strong>Playable</strong>: Runs well, only minor graphical or audio glitches. Games can be played all the way through." %}
+                            </div>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="row">
+                            <div class="col-auto">
+                                {% trans "Starts" as starts_text %}
+                                {% include "compat-rating-responsive.html" with rating="3" rating_text=starts_text %}
+                            </div>
+                            <div class="col">
+                                {% trans "<strong>Starts</strong>: Starts, maybe even plays well, but crashes or major graphical/audio glitches." %}
+                            </div>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="row">
+                            <div class="col-auto">
+                                {% trans "Intro/Menu" as intro_menu_text %}
+                                {% include "compat-rating-responsive.html" with rating="2" rating_text=intro_menu_text %}
+                            </div>
+                            <div class="col">
+                                {% trans "<strong>Intro/Menu</strong>: Hangs/crashes somewhere between booting and starting." %}
+                            </div>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="row">
+                            <div class="col-auto">
+                                {% trans "Broken" as broken_text %}
+                                {% include "compat-rating-responsive.html" with rating="1" rating_text=broken_text %}
+                            </div>
+                            <div class="col">
+                                {% trans "<strong>Broken</strong>: Crashes when booting." %}
+                            </div>
+                        </div>
+                    </li>
+                </ul>
+            </div>
+        </div>
 
-        <ul>
-            <li><img src="{% static "img/stars/5.png" %}" alt="{% trans "5 out of 5" %}"> {% trans "<strong>Perfect</strong>: No issues at all!" %}</li>
-            <li><img src="{% static "img/stars/4.png" %}" alt="{% trans "4 out of 5" %}"> {% trans "<strong>Playable</strong>: Runs well, only minor graphical or audio glitches. Games can be played all the way through." %}</li>
-            <li><img src="{% static "img/stars/3.png" %}" alt="{% trans "3 out of 5" %}"> {% trans "<strong>Starts</strong>: Starts, maybe even plays well, but crashes or major graphical/audio glitches." %}</li>
-            <li><img src="{% static "img/stars/2.png" %}" alt="{% trans "2 out of 5" %}"> {% trans "<strong>Intro/Menu</strong>: Hangs/crashes somewhere between booting and starting." %}</li>
-            <li><img src="{% static "img/stars/1.png" %}" alt="{% trans "1 out of 5" %}"> {% trans "<strong>Broken</strong>: Crashes when booting." %}</li>
-        </ul>
+        <div class="col-md-3 col-12">
+            <div class="ratings-stats">
+            <h3>{% trans "Statistics" %}</h3>
+
+            <dl class="mt-3 mb-0">
+                {% for rating in all_ratings %}
+                <dt>
+                    {% if filter_by == rating %}
+                    <a href="{% compat_url page None %}" title="{% trans "Remove filter" %}" class="pull-end">{% trans "Show all" %}</a>
+                    {% else %}
+                    <a href="{% compat_url page rating %}" title="{% trans "Filter by this rating" %}" class="pull-end"><i class="bi bi-funnel-fill" role="img" aria-label="Filter"></i> {% trans "Filter" %}</a>
+                    {% endif %}
+                    {{ rating|compat_text }}: {{ rating|rating_pct|floatformat }}%
+                </dt>
+                <dd>
+                    <div class="progress">
+                        <div class="progress-bar bg-{{ rating|rating_class }}" style="width: {{ rating|rating_pct|unlocalize }}%"></div>
+                    </div>
+                </dd>
+                {% endfor %}
+            </dl>
+            </div>
         </div>
     </div>
-
-    <div class="col-md-3 well col">
-        <div class="ratings-stats">
-        <h3>{% trans "Statistics" %}</h3>
-
-        <dl>
-        {% for rating in all_ratings %}
-        <dt>
-            {% if filter_by == rating %}
-            <a href="{% compat_url page None %}" title="{% trans "Remove filter" %}" class="pull-end">{% trans "Show all" %}</a>
-            {% else %}
-            <a href="{% compat_url page rating %}" title="{% trans "Filter by this rating" %}" class="pull-end"><i class="icon-filter"></i> {% trans "Filter" %}</a>
-            {% endif %}
-            {{ rating|compat_text }}: {{ rating|rating_pct|floatformat }}%
-        </dt>
-        <dd><div class="progress"><div class="progress-bar progress-bar-{{ rating|rating_class }}" style="width: {{ rating|rating_pct|unlocalize }}%"></div></div></dd>
-        {% endfor %}
-        </dl>
-        </div>
-    </div>
-</div>
 </div>
 
 {% include "compat-list-pagi.html" %}
 
 {% if games %}
-<table class="compat-list">
+<table class="table table-striped table-sm align-middle table-borderless compat-list">
     <thead>
         <tr>
-            <th class="category"></th>
-            <th class="banner"></th>
-            <th class="title">{% trans "Game title (click for details)" %}</th>
-            <th class="rating">{% trans "Compatibility" %}</th>
-            <th class="update">{% trans "Last updated" %}</th>
+            <th scope="col" class="category"></th>
+            <th scope="col" class="banner"></th>
+            <th scope="col" class="title">{% trans "Game title" %}</th>
+            <th scope="col" class="rating">{% trans "Compatibility" %}</th>
+            <th scope="col" class="update d-none d-sm-table-cell">{% trans "Last updated" %}</th>
         </tr>
     </thead>
 
@@ -73,9 +126,11 @@
         <tr>
             <td class="category"><img src="{% platform_img_url cat %}" width="32" height="32" alt="{{ cat|capfirst }}" title="{{ cat|capfirst }}"></td>
             <td class="banner"><div class="bnr bnr-{{ hash }}"></div></td>
-            <td class="title always-ltr"><a href="{{ game.wiki_url }}">{{ game.title }}</a></td>
-            <td class="rating"><img src="{% compat_img_url game.latest.text.data %}" alt="{{ game.latest.text.data|compat_text }}" title="{{ game.latest.text.data|compat_text }}"></td>
-            <td class="update">{{ ts|naturaltime }}</td>
+            <td class="title always-ltr"><a href="{{ game.wiki_url }}">{{ game.title }} - {{ game.latest.text.data }}</a></td>
+            <td class="rating">
+                {% include "compat-rating-responsive.html" with rating=game.latest.text.data rating_text=game.latest.text.data|compat_text %}
+            </td>
+            <td class="update d-none d-sm-table-cell">{{ ts|naturaltime }}</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/dolweb/compat/templates/compat-rating-responsive.html
+++ b/dolweb/compat/templates/compat-rating-responsive.html
@@ -1,0 +1,13 @@
+{% load compat %}
+<span class="d-none d-sm-inline badge bg-{{ rating|rating_class }}" title="{{ rating_text }}">
+    {% for i in '12345'|make_list %}
+        {% if i <= rating %}
+            <i class="bi bi-star-fill"></i>
+        {% else %}
+            <i class="bi bi-star"></i>
+        {% endif %}
+    {% endfor %}
+</span>
+<span class="d-inline d-sm-none badge bg-{{ rating|rating_class }}" title="{{ rating_text }}">
+    <i class="bi bi-star-fill"></i> {{ rating }}/5
+</span>

--- a/dolweb/docs/templates/docs-faq.html
+++ b/dolweb/docs/templates/docs-faq.html
@@ -9,30 +9,30 @@
 {% block "body" %}
 <div class="row">
     <div class="col-md-3">
-        <div class="well sidebar-nav">
-            <ul class="nav">
+        <div class="sidebar-nav mt-5">
+            <ul class="nav flex-column">
                 {% for category in categories %}
-                <li class="faq-cat">{{ category.title|faq_translate }}</li>
+                <li class="faq-cat nav-item">{{ category.title|faq_translate }}</li>
                 {% for question in category.sorted_questions %}
-                <li class="faq-title"><a href="#{{ question.slug }}">{{ question.short_title|faq_translate }}</a></li>
+                <li class="faq-title nav-item"><a href="#{{ question.slug }}" class="nav-link">{{ question.short_title|faq_translate }}</a></li>
                 {% endfor %}
                 {% endfor %}
             </ul>
         </div>
     </div>
     <div class="col-md-9">
-        <div style="text-align: center;">
-        <script type="text/javascript"><!--
-        google_ad_client = "ca-pub-8646203626363069";
-        /* FAQ page ad */
-        google_ad_slot = "4072573718";
-        google_ad_width = 728;
-        google_ad_height = 90;
-        //-->
-        </script>
-        <script type="text/javascript"
-        src="//pagead2.googlesyndication.com/pagead/show_ads.js">
-        </script>
+        <div class="text-center mt-5">
+            <script type="text/javascript"><!--
+            google_ad_client = "ca-pub-8646203626363069";
+            /* FAQ page ad */
+            google_ad_slot = "4072573718";
+            google_ad_width = 728;
+            google_ad_height = 90;
+            //-->
+            </script>
+            <script type="text/javascript"
+            src="//pagead2.googlesyndication.com/pagead/show_ads.js">
+            </script>
         </div>
     {% for category in categories %}
         <section id="{{ category.slug }}" class="faq-section">

--- a/dolweb/docs/templates/docs-guide.html
+++ b/dolweb/docs/templates/docs-guide.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block "body" %}
-<p><a class="back-link" href="{% url 'docs_guides_index' %}">« {% trans "Go back to the guides list" %}</a></p>
+<p class="mt-3"><a class="back-link" href="{% url 'docs_guides_index' %}">« {% trans "Go back to the guides list" %}</a></p>
 
 <div style="text-align: center;">
 <script type="text/javascript"><!--

--- a/dolweb/docs/templates/docs-guides-index.html
+++ b/dolweb/docs/templates/docs-guides-index.html
@@ -8,7 +8,7 @@
 
 {% block "body" %}
 <div class="page-header">
-    <h1>{% trans "Guides and documentation" %}</h1>
+    <h1 class="mt-5">{% trans "Guides and documentation" %}</h1>
 </div>
 
 <dl>

--- a/dolweb/docs/templates/docs-privacy.html
+++ b/dolweb/docs/templates/docs-privacy.html
@@ -6,7 +6,7 @@
 {% block "title" %}{% trans "Privacy Policy" %}{% endblock %}
 
 {% block "body" %}
-<h1>Privacy Policy</h1>
+<h1 class="mt-5">Privacy Policy</h1>
 <p>As contributors to the Dolphin Emulator project, we always try our best to keep our users' best interests in mind. Dolphin and some of its associated services (for example, this website) do sometimes collect information about our users and their activities. This page will attempt to explain in what situations we collect data, how we process it, and how do we keep it secure if needed.</p>
 
 <h3>Emulation Software</h3>

--- a/dolweb/downloads/templates/downloads-devrel.html
+++ b/dolweb/downloads/templates/downloads-devrel.html
@@ -1,22 +1,21 @@
 {% load humanize %}
 {% load i18n %}
 
-<table class="versions-list dev-versions">
-    <tbody>
+<div class="row versions-list gy-3">
     {% for ver in builds %}
-        <tr class="infos">
-            <td class="version always-ltr"><a href="{{ ver.get_absolute_url }}">{{ ver.shortrev }}</a></td>
-            <td class="reldate" title="{{ ver.date|date:"c" }}">{{ ver.date|naturaltime }}</td>
-            <td class="description always-ltr">{{ ver.description_abbrev }}</td>
-        </tr>
-        <tr class="download">
-            <td></td>
-            <td class="download-links" colspan="2">
-                {% include "downloads-links.html" with primclass=primclass %}
-            </td>
-        </tr>
+        <div class="col-6 col-md-4 col-lg-3 version always-ltr">
+            <p class="mb-0">
+                <a href="{{ ver.get_absolute_url }}">{{ ver.shortrev }}</a>
+            </p>
+            <span class="badge bg-light text-dark" title="{{ ver.date|date:"c" }}">{{ ver.date|naturaltime }}</span>
+        </div>
+        <div class="col-6 col-md-8 col-lg-9 description always-ltr">
+            <i>{{ ver.description_abbrev }}</i>
+        </div>
+        <div class="col-12 download-links pb-3 border-bottom">
+            {% include "downloads-links.html" with primclass=primclass %}
+        </div>
     {% empty %}
-    <tr><td colspan="3"><em>{% trans "No development release yet" %}</em></td></tr>
+    <div class="col">{% trans "No development release yet" %}</div>
     {% endfor %}
-    </tbody>
-</table>
+</div>

--- a/dolweb/downloads/templates/downloads-index.html
+++ b/dolweb/downloads/templates/downloads-index.html
@@ -23,12 +23,12 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 </script>
 </div>
 
-<div class="page-header">
-    <h1>{% trans "Download" %}</h1>
+<div class="page-header border-bottom mb-3">
+    <h1 class="mt-5">{% trans "Download" %}</h1>
 </div>
 
 <div id="download-beta">
-<h1>{% trans "Beta versions" %}</h1>
+<h2>{% trans "Beta versions" %}</h2>
     
 <div class="alert alert-info">{% blocktrans %}
     <p>Beta versions are released every month, usually accompanied by a <em>Progress Report</em>
@@ -45,7 +45,7 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 </div>
 
 <div id="download-dev">
-<h1>{% trans "Development versions" %}</h1>
+<h2>{% trans "Development versions" %}</h2>
     
 <div class="alert alert-info">
     <p>{% blocktrans %}Development versions are released every time a developer makes a change to
@@ -60,7 +60,7 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 
 {% include "downloads-devrel.html" with builds=master_builds primclass='btn-info' %}
 
-<p><a class="btn" href="{% url 'downloads_list' "master" 1 %}">{% trans "View older versions »" %}</a></p>
+<p><a class="btn btn-secondary" href="{% url 'downloads_list' "master" 1 %}">{% trans "View older versions »" %}</a></p>
 </div>
 
 <div style="text-align: center;">
@@ -78,40 +78,35 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 </div>
 
 <div id="download-stable">
-<h1>{% trans "Stable versions" %}</h2>
+    <h2>{% trans "Stable versions" %}</h2>
 
-{# TODO: Update when 6.0 is released #}
-<div class="alert alert-warning">{% blocktrans %}
-    The stable versions below are years out of date and missing countless features and bug fixes.
-    <a href="#download-beta">Beta</a> or <a href="#download-dev">development</a> versions are a
-    better choice for almost all users; the stable versions should only be used if you have
-    a specific need for them.
-{% endblocktrans %}</div>
+    {# TODO: Update when 6.0 is released #}
+    <div class="alert alert-warning">{% blocktrans %}
+        The stable versions below are years out of date and missing countless features and bug fixes.
+        <a href="#download-beta">Beta</a> or <a href="#download-dev">development</a> versions are a
+        better choice for almost all users; the stable versions should only be used if you have
+        a specific need for them.
+    {% endblocktrans %}</div>
 
-<table class="versions-list stable-versions">
-    <tbody>
-    {% for ver in releases %}
-        <tr class="infos">
-            <td class="version always-ltr">Dolphin {{ ver.version }}</td>
-            <td class="reldate">{{ ver.date|naturaltime }}</td>
-            <td class="description"></td>
-        </tr>
-        <tr class="download">
-            <td></td>
-            <td class="download-links" colspan="2">
+    <div class="row versions-list stable-versions gy-3">
+        {% for ver in releases %}
+            <div class="col-6 col-md-4 col-lg-3 version always-ltr">
+                <p class="mb-0">
+                    Dolphin {{ ver.version }}
+                </p>
+                <span class="badge bg-light text-dark" title="{{ ver.date|date:"c" }}">{{ ver.date|naturaltime }}</span>
+            </div>
+            <div class="col-12 download-links pb-3 border-bottom">
                 {% include "downloads-links.html" %}
-            </td>
-        </tr>
-        </li>
-    {% empty %}
-        <tr><td colspan="2"><em>{% trans "No stable release yet" %}</em></td></tr>
-    {% endfor %}
-    </tbody>
-</table>
+            </div>
+        {% empty %}
+            <div class="col">{% trans "No stable release yet" %}</div>
+        {% endfor %}
+    </div>
 </div>
 
 <div id="other-linux">
-    <h1>{% trans "Linux distributions" %}</h1>
+    <h2>{% trans "Linux distributions" %}</h2>
     <p>{% blocktrans %}Ubuntu users can install a PPA
     for development and stable versions of Dolphin here: <a href="https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu">Installing Dolphin</a>
     {% endblocktrans %}</p>
@@ -120,7 +115,7 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 </div>
 
 <div id="download-source">
-    <h1>{% trans "Source code" %}</h1>
+    <h2>{% trans "Source code" %}</h2>
 
     <p>{% blocktrans %}
     The latest version of the Dolphin source code can be downloaded from the
@@ -137,7 +132,7 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 </div>
 
 <div id="report-bugs">
-    <h1>{% trans "Reporting bugs" %}</h1>
+    <h2>{% trans "Reporting bugs" %}</h2>
 
     <p>{% blocktrans %}
     For reporting bugs please go to <a href="{{ ISSUES_URL }}">the issue tracker</a>.

--- a/dolweb/downloads/templates/downloads-links.html
+++ b/dolweb/downloads/templates/downloads-links.html
@@ -1,5 +1,14 @@
 {% load artifacts %}
 
 {% for artifact in ver.artifacts.all|artifact_sort %}
-<a href="{{ artifact.url }}" class="btn always-ltr {% if USER_OS == "unknown" or USER_OS == artifact.user_os_matcher %}{{ primclass|default:"btn-primary" }}{% endif %} {{ artifact.user_os_matcher }}"><i class="icon-download-alt"></i> {{ artifact.target_system }}</a>
+    <a href="{{ artifact.url }}" class="btn always-ltr
+        {% if USER_OS == "unknown" or USER_OS == artifact.user_os_matcher %}
+            {{ primclass|default:"btn-primary" }}
+        {% else %}
+            btn-light
+        {% endif %}
+        {{ artifact.user_os_matcher }}">
+        <i class="bi bi-download"></i>
+        {{ artifact.target_system }}
+    </a>
 {% endfor %}

--- a/dolweb/downloads/templates/downloads-list-pagi.html
+++ b/dolweb/downloads/templates/downloads-list-pagi.html
@@ -1,39 +1,37 @@
-<div class="text-center">
-<ul class="pagination">
+<ul class="pagination justify-content-center">
     {% if page_obj.has_previous %}
-    <li><a href="{% url 'downloads_list' branch page_obj.previous_page_number %}">&larr;</a></li>
+    <li class="page-item"><a class="page-link" href="{% url 'downloads_list' branch page_obj.previous_page_number %}" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a></li>
     {% else %}
-    <li class="disabled"><a href="#">&larr;</a></li>
+    <li class="page-item disabled"><a class="page-link" href="#" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a></li>
     {% endif %}
 
     {% for page in page_obj.leading_range %}
-    <li><a href="{% url 'downloads_list' branch page %}">{{ page }}</a></li>
+    <li class="page-item"><a class="page-link" href="{% url 'downloads_list' branch page %}">{{ page }}</a></li>
     {% endfor %}
 
     {% if page_obj.leading_range %}
-    <li class="disabled"><span>&hellip;</span></li>
+    <li class="page-item disabled"><span>&hellip;</span></li>
     {% endif %}
 
     {% for page in page_obj.main_range %}
     {% if page == page_obj.number %}
-    <li class="active"><a href="#">{{ page }}</a></li>
+    <li class="page-item active"><a class="page-link" href="#">{{ page }}</a></li>
     {% else %}
-    <li><a href="{% url 'downloads_list' branch page %}">{{ page }}</a></li>
+    <li class="page-item"><a class="page-link" href="{% url 'downloads_list' branch page %}">{{ page }}</a></li>
     {% endif %}
     {% endfor %}
 
     {% if page_obj.trailing_range %}
-    <li class="disabled"><span>&hellip;</span></li>
+    <li class="page-item disabled"><span>&hellip;</span></li>
     {% endif %}
 
     {% for page in page_obj.trailing_range %}
-    <li><a href="{% url 'downloads_list' branch page %}">{{ page }}</a></li>
+    <li class="page-item"><a class="page-link" href="{% url 'downloads_list' branch page %}">{{ page }}</a></li>
     {% endfor %}
 
     {% if page_obj.has_next %}
-    <li><a href="{% url 'downloads_list' branch page_obj.next_page_number %}">&rarr;</a></li>
+    <li class="page-item"><a class="page-link" href="{% url 'downloads_list' branch page_obj.next_page_number %}" aria-label="Next"><span aria-hidden="true">&raquo;</span></a></li>
     {% else %}
-    <li class="disabled"><a href="#">&rarr;</a></li>
+    <li class="page-item disabled"><a class="page-link" href="#" aria-label="Next"><span aria-hidden="true">&raquo;</span></a></li>
     {% endif %}
 </ul>
-</div>

--- a/dolweb/downloads/templates/downloads-list.html
+++ b/dolweb/downloads/templates/downloads-list.html
@@ -5,8 +5,8 @@
 {% block "title" %}{% blocktrans %}{{ branch }} branch - page {{ page }}{% endblocktrans %}{% endblock %}
 
 {% block "body" %}
-<div class="page-header">
-    <h1>{% blocktrans %}<tt>{{ branch }}</tt> branch - page {{ page }}{% endblocktrans %}</h1>
+<div class="page-header border-bottom mb-3">
+    <h1 class="mt-5">{% blocktrans %}<tt>{{ branch }}</tt> branch - page {{ page }}{% endblocktrans %}</h1>
 </div>
 
 {% include "downloads-list-pagi.html" %}

--- a/dolweb/downloads/templates/downloads-view-devrel.html
+++ b/dolweb/downloads/templates/downloads-view-devrel.html
@@ -7,7 +7,7 @@
 
 {% block "body" %}
 <div class="page-header">
-    <h1>{% blocktrans with br=ver.revbranch %}Information for {{ br }}{% endblocktrans %}</h1>
+    <h1 class="mt-5">{% blocktrans with br=ver.revbranch %}Information for {{ br }}{% endblocktrans %}</h1>
 </div>
 
 <div style="text-align: center;">

--- a/dolweb/homepage/templates/homepage-home.html
+++ b/dolweb/homepage/templates/homepage-home.html
@@ -30,22 +30,47 @@
 <link href="{% static "css/ekko-lightbox.min.css" %}" rel="stylesheet">
 {% endblock %}
 
-{% block "body" %}
+{% block "outerbody" %}
 <div class="jumbotron my-hero">
-    <div class="row">
-        <div class="col-md-6">
-            <h1 class="title">{% trans "Dolphin Emulator" %}</h1>
+    <div id="carousel-sshot" class="carousel slide" data-bs-ride="carousel">
+        <div class="carousel-inner">
+            {% for image in featured_images %}
+            <div class="carousel-item {% if forloop.counter == 1 %}active{% endif %}">
+                {% thumbnail image.image "1296x512" crop="center" format="JPEG" quality=80 as big %}
+                    <img src="{{ big.url }}" alt="{{ image.game_name }}" class="d-inline">
+                {% endthumbnail %}
+            </div>
+            {% endfor %}
+        </div>
+{#                <button class="carousel-control-prev" type="button" data-bs-target="#carousel-sshot" data-bs-slide="prev">#}
+{#                    <span class="carousel-control-prev-icon" aria-hidden="true"></span>#}
+{#                    <span class="visually-hidden">Previous</span>#}
+{#                </button>#}
+{#                <button class="carousel-control-next" type="button" data-bs-target="#carousel-sshot" data-bs-slide="next">#}
+{#                    <span class="carousel-control-next-icon" aria-hidden="true"></span>#}
+{#                    <span class="visually-hidden">Next</span>#}
+{#                </button>#}
+    </div>
+    <div class="container">
+        <div class="main-header text-light">
+            <h1 class="title">
+                {% trans "Dolphin Emulator" %}
+            </h1>
             <p class="intro">
-            {% blocktrans %}
-            <b>Dolphin</b> is an emulator for two recent Nintendo video game
-            consoles: the <b>GameCube</b> and the <b>Wii</b>. It allows PC
-            gamers to enjoy games for these two consoles in <b>full HD</b>
-            (1080p) with several enhancements: compatibility with all PC
-            controllers, turbo speed, networked multiplayer, and even more!
-            {% endblocktrans %}
+                {% blocktrans %}
+                <b>Dolphin</b> is an emulator for two recent Nintendo video game
+                consoles: the <b>GameCube</b> and the <b>Wii</b>. It allows PC
+                gamers to enjoy games for these two consoles in <b>full HD</b>
+                (1080p) with several enhancements: compatibility with all PC
+                controllers, turbo speed, networked multiplayer, and even more!
+                {% endblocktrans %}
             </p>
 
-            <p class="download-btn"><a class="btn btn-primary btn-lg" href="{% url 'downloads_index' %}?ref=btn"><i class="icon-download-alt"></i> {% blocktrans %}Download {{ last_release }} for Windows, Mac and Linux »{% endblocktrans %}</a></p>
+            <p class="download-btn">
+                <a class="btn btn-primary btn-lg text-start" href="{% url 'downloads_index' %}?ref=btn">
+                    <i class="bi bi-download main-download-icon"></i> {% blocktrans %}Download {{ last_release }} for Windows, Mac and Linux »{% endblocktrans %}
+                </a>
+            </p>
             {% if FB_LIKE_PAGE %}
             <div class="fb-like" data-href="{{ FB_LIKE_PAGE }}" data-send="false" data-layout="button_count" data-width="100" data-show-faces="true"></div>
             {% endif %}
@@ -53,33 +78,16 @@
             <div class="g-plusone" data-size="small" data-href="{{ GPLUS_LIKE_PAGE }}"></div>
             {% endif %}
         </div>
-        <div class="col-md-6">
-            <div id="carousel-sshot" class="carousel slide">
-                <div class="carousel-inner">
-                    {% for image in featured_images %}
-                    <div class="item {% if forloop.counter == 1 %}active{% endif %}">
-                        {% thumbnail image.image "853x480" crop="center" format="JPEG" quality=80 as big %}
-                            <img src="{{ big.url }}" alt="{{ image.game_name }}">
-                        {% endthumbnail %}
-                        <div class="carousel-caption">
-                            <h3>&nbsp;</h3>
-                            <p>{{ image.game_name }}</p>
-                        </div>
-                    </div>
-                    {% endfor %}
-                </div>
-                  <a class="left carousel-control" href="#carousel-sshot" data-slide="prev"><span class="icon-prev"></span></a>
-                  <a class="right carousel-control" href="#carousel-sshot" data-slide="next"><span class="icon-next"></span></a>
-            </div>
-        </div>
     </div>
 </div>
+{% endblock %}
 
-<div class="row sshot-row hidden-sm hidden-xs">
+{% block "body" %}
+<div class="row sshot-row">
     {% for image in featured_images %}
-    <div class="col-md-2 sshot-col">
+    <div class="col-4 col-md-2 sshot-col">
         {% thumbnail image.image "x1080" upscale=False format="JPEG" quality=80 as big %}
-        <a href="{{ big.url }}" data-toggle="lightbox" data-gallery="featured" data-title="{{ image.game_name }}">
+        <a href="#" data-src="{{ big.url }}" data-toggle="lightbox" data-title="{{ image.game_name }}" data-bs-toggle="modal" data-bs-target="#lightbox-modal">
             {% thumbnail image.image "640x360" crop="center" format="JPEG" quality=80 as small %}
             <img src="{{ small.url }}" alt="{{ image.game_name }}" class="fp-sshot">
             {% endthumbnail %}
@@ -91,53 +99,71 @@
 
 <div class="row" style="margin-top: 1em">
     <div class="col-md-3">
-        <div class="realign ratings-stats well">
-            <h4><a href="{% url 'compat_index' %}">{% trans "Compatibility" %} »</a></h4>
-
-            <dl>
-            {% for rating in all_ratings %}
-            <dt>{{ rating|compat_text }}: {{ rating|rating_pct|floatformat }}%</dt>
-            <dd><div class="progress"><div class="progress-bar progress-bar-{{ rating|rating_class }}" style="width: {{ rating|rating_pct|unlocalize }}%"></div></div></dd>
-            {% endfor %}
-            </dl>
+        <h2 class="d-none d-md-block">&nbsp;{# Required for vertical alignment on >= md #}</h2>
+        <div class="card mb-3">
+            <div class="card-header">
+                <a href="{% url 'compat_index' %}">{% trans "Compatibility" %} »</a>
+            </div>
+            <div class="card-body">
+                <dl>
+                    {% for rating in all_ratings %}
+                        <dt>{{ rating|compat_text }}: {{ rating|rating_pct|floatformat }}%</dt>
+                        <dd>
+                            <div class="progress">
+                                <div class="progress-bar bg-{{ rating|rating_class }}"
+                                     style="width: {{ rating|rating_pct|unlocalize }}%"></div>
+                            </div>
+                        </dd>
+                    {% endfor %}
+                </dl>
+            </div>
         </div>
 
         {% include "blog_sidebar.html" %}
     </div>
     <div class="col-md-9">
-        <a href="{% url 'zinnia:entry_feed' %}" class="rss-tag pull-right" title="{% trans "RSS feed of the latest articles" %}"><i class="icon-rss"></i></a>
-        <h2 class="latest-articles">{% trans "Latest articles" %}</h2>
+        <div class="mt-md-auto mt-3">
+            <a href="{% url 'zinnia:entry_feed' %}" class="rss-tag float-end" title="{% trans "RSS feed of the latest articles" %}"><i class="bi bi-rss" role="button" aria-label="RSS"></i></a>
+            <h2 class="latest-articles">{% trans "Latest articles" %}</h2>
+        </div>
+
         {% for article in home_articles %}
-        <div class="well">
-            <h3><a href="{{ article.get_absolute_url }}" title="{{ article.title }}" rel="bookmark">
-                {{ article.title }}
-            </a></h3>
-             <div class="entry-meta-line">
-                <p class="entry-info">
-                  {% with authors=article.authors.all %}
-                  {% if authors|length %}
-                  {% trans "Written by" %}
-                  {% for author in authors %}
-                  <span class="vcard author">
+        <div class="card mb-3">
+            <div class="card-body">
+                <h4 class="card-title">
+                    <a href="{{ article.get_absolute_url }}" title="{{ article.title }}" rel="bookmark">
+                        {{ article.title }}
+                    </a>
+                </h4>
+                <div class="entry-meta-line">
+                    <p class="entry-info">
+                        {% with authors=article.authors.all %}
+                            {% if authors|length %}
+                                {% trans "Written by" %}
+                                {% for author in authors %}
+                                    <span class="vcard author">
                     <a href="{{ author.get_absolute_url }}" class="fn url{% if not author.get_full_name %} nickname{% endif %}" rel="author"
                        title="{% blocktrans %}Show all {{ author }}'s entries{% endblocktrans %}">{{ author }}</a></span>{% if not forloop.last %}, {% endif %}
-                  {% endfor %}
-                  {% trans "on" %}
-                  {% else %}
-                  {% trans "Written on" %}
-                  {% endif %}
-                  {% endwith %}
-                  <abbr class="published" title="{{ article.publication_date|date:"c" }}">{{ article.publication_date|date:"DATE_FORMAT" }}</abbr>
-                  {% if article.within_series %}
-                  {% url 'dolweb_blog_series' uid=article.within_series.pk as series_url %}
-                  {% blocktrans with url=series_url name=article.within_series.name %}/ Part of series <a href="{{ url }}">{{ name}}</a>{% endblocktrans %}
-                  {% endif %}
-                  {% if article.forum_thread %}/ <i class="icon-comments"></i> <a href="{{ article.forum_thread.get_absolute_url }}" title="{% trans "Visit forum thread for this article" %}">{% trans "Forum thread" %}</a>{% endif %}
-               </p>
-            </div>
-            <div class="entry-content">
-                {{ article.html_content|cuthere_excerpt|safe }}
-                <p><a href="{{ article.get_absolute_url }}#cuthere">{% trans "Read this article" %}</a></p>
+                                {% endfor %}
+                                {% trans "on" %}
+                            {% else %}
+                                {% trans "Written on" %}
+                            {% endif %}
+                        {% endwith %}
+                        <abbr class="published" title="{{ article.publication_date|date:"c" }}">{{ article.publication_date|date:"DATE_FORMAT" }}</abbr>
+                        {% if article.within_series %}
+                            {% url 'dolweb_blog_series' uid=article.within_series.pk as series_url %}
+                            {% blocktrans with url=series_url name=article.within_series.name %}/ Part of series <a href="{{ url }}">{{ name}}</a>{% endblocktrans %}
+                        {% endif %}
+                        {% if article.forum_thread %}/ <i class="bi bi-chat-fill"></i> <a href="{{ article.forum_thread.get_absolute_url }}" title="{% trans "Visit forum thread for this article" %}">{% trans "Forum thread" %}</a>{% endif %}
+                    </p>
+                </div>
+                <div class="entry-content">
+                    {{ article.html_content|cuthere_excerpt|safe }}
+                    <div>
+                        <a href="{{ article.get_absolute_url }}#cuthere">{% trans "Read this article" %}</a>
+                    </div>
+                </div>
             </div>
         </div>
         {% empty %}
@@ -145,11 +171,9 @@
         {% endfor %}
     </div>
 </div>
-
 {% endblock %}
 
 {% block "extrajs" %}
-<script src="{% static "js/ekko-lightbox.min.js" %}"></script>
 <script>
     {% if GPLUS_LIKE_PAGE %}
     (function() {
@@ -158,22 +182,5 @@
         var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
     })();
     {% endif %}
-
-    $(document).ready(function () {
-        $('.carousel').carousel({
-            interval: 7500
-        });
-
-        $('.carousel').carousel('cycle');
-    });
-
-    $(document).ready(function($) {
-        $(document).delegate('*[data-toggle="lightbox"]', 'click', function(event) {
-            event.preventDefault();
-            return $(this).ekkoLightbox({
-                always_show_close: true
-            });
-        });
-    });
 </script>
 {% endblock %}

--- a/dolweb/media/templates/media-all.html
+++ b/dolweb/media/templates/media-all.html
@@ -8,38 +8,26 @@
 
 {% block "title" %}{% trans "Screenshots gallery" %}{% endblock %}
 
-{% block "extracss" %}
-<link href="{% static "css/ekko-lightbox.min.css" %}" rel="stylesheet">
-{% endblock %}
-
-{% block "extrajs" %}
-<script src="{% static "js/ekko-lightbox.min.js" %}"></script>
-<script>
-$(document).ready(function($) {
-    $(document).delegate('*[data-toggle="lightbox"]', 'click', function(event) {
-        event.preventDefault();
-        return $(this).ekkoLightbox({
-            always_show_close: true
-        });
-    });
-});
-</script>
-{% endblock %}
-
 {% block "body" %}
 <div class="page-header">
-    <h1>{% trans "Media gallery" %}</h1>
+    <h1 class="mt-5">{% trans "Media gallery" %}</h1>
 </div>
 
-<div id="gallery" data-toggle="modal-gallery" data-target="#modal-gallery">
+<div id="gallery" data-gallery="media-gallery">
+    <div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-6 g-4">
     {% for image in images %}
-    {% thumbnail image.image "x1080" upscale=False format="JPEG" quality=80 as big %}
-    <a href="{{ big.url }}" data-toggle="lightbox" data-gallery="media" data-title="{{ image.game_name }}">
-        {% thumbnail image.image "150x150" crop="center" as small %}
-        <img style="width: 150px; height: 150px;" src="{{ small.url }}" alt="{{ image.game_name }}">
+        {% thumbnail image.image "x1080" upscale=False format="JPEG" quality=80 as big %}
+            <div class="col">
+                <div class="card m-auto" style="width: 150px;">
+                    <a href="#" data-src="{{ big.url }}" data-toggle="lightbox" data-bs-toggle="modal" data-bs-target="#lightbox-modal" data-title="{{ image.game_name }}">
+                        {% thumbnail image.image "150x150" crop="center" as small %}
+                            <img style="width: 150px; height: 150px;" src="{{ small.url }}" alt="{{ image.game_name }}" class="card-img">
+                        {% endthumbnail %}
+                    </a>
+                </div>
+            </div>
         {% endthumbnail %}
-    </a>
-    {% endthumbnail %}
     {% endfor %}
+    </div>
 </div>
 {% endblock %}

--- a/dolweb/static/css/dolphin.css
+++ b/dolweb/static/css/dolphin.css
@@ -1,3 +1,16 @@
+/*default anchor style*/
+a{
+    text-decoration: none;
+}
+
+a:not(.btn):not(.page-link):hover{
+    text-decoration: underline;
+}
+
+.nav>li>a:hover{
+    text-decoration: none;
+}
+
 /* LTR/RTL util classes */
 .always-ltr {
     direction: ltr;
@@ -16,11 +29,11 @@ html[dir="rtl"] .default-dir {
 }
 
 /* Align some table text cells to the right (always English ltr text) */
-html[dir="rtl"] table.versions-list td.description {
+html[dir="rtl"] .versions-list .description {
     text-align: right;
 }
 
-html[dir="rtl"] table.compat-list td.title {
+html[dir="rtl"] .compat-list .title {
     text-align: right;
 }
 
@@ -87,17 +100,85 @@ h5:hover a.headerlink {
     visibility: visible;
 }
 
+/* Gallery */
 #gallery {
     text-align: center;
 }
 
-#gallery > a {
-    border: 1px solid #777;
-    display: inline-block;
-    margin: 0 1.5em 1.5em 0;
-    padding: 4px;
+#lightbox-modal .arrow-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 100;
+    width: 100%;
+    height: 100%;
 }
 
+#lightbox-modal .arrow {
+    color: #fff;
+    opacity: 0.4;
+    z-index: 100;
+    display: block;
+    width: 49%;
+    height: 100%;
+    font-size: 30px;
+    text-shadow: 0 1px 3px #000;
+    transition-duration: 0.1s;
+}
+
+#lightbox-modal .arrow > i {
+    display: inline-block;
+    top: 50%;
+    transform: translateY(-50%);
+    position: absolute;
+}
+
+#lightbox-modal .arrow.previous > i{
+    left: 30px;
+}
+
+#lightbox-modal .arrow.next > i{
+    right: 30px;
+}
+
+#lightbox-modal .arrow:hover{
+    opacity: 1;
+}
+
+#lightbox-modal .arrow.previous {
+    left: 0;
+    float: left;
+    text-align: left;
+}
+
+#lightbox-modal .arrow.next {
+    right: 0;
+    float: right;
+    text-align: right;
+}
+
+#lightbox-modal .backdrop{
+    width: 100%;
+    height: 100%;
+    z-index: 0;
+    background-color: #000;
+    overflow: hidden;
+}
+
+#lightbox-modal .backdrop-img{
+    width: calc(100% + 32px);
+    height: calc(100% + 32px);
+    filter: blur(16px);
+    opacity: 0.2;
+    object-fit: cover;
+}
+
+#lightbox-modal .lightbox-img{
+    position: relative;
+    z-index: 1;
+}
+
+/* Downloads */
 #download-dev a.all-branches {
     font-weight: bold;
 }
@@ -111,53 +192,12 @@ h5:hover a.headerlink {
     margin-bottom: 1em;
 }
 
-.versions-list td.version {
+.versions-list .version {
     font-weight: bold;
-    text-align: center;
-    width: 10%;
-}
-
-.versions-list td.reldate {
-    text-align: center;
-    width: 15%;
-}
-
-.versions-list td.description {
-    width: 65%;
-    font-style: italic;
-}
-
-.versions-list tr.infos td {
-    padding-bottom: 0.5em;
-}
-
-div#download-stable, div#download-dev {
-    margin-bottom: 3em;
-}
-
-div#download-stable h1, div#download-dev h1, div#download-source h1 {
-    margin-bottom: 0.5em;
-}
-
-.versions-list tr:first-child {
-    border-top: 1px solid #CCC;
 }
 
 .versions-list tr.infos td {
     padding-top: 0.6em;
-}
-
-.versions-list tr.download {
-    border-bottom: 1px solid #CCC;
-}
-
-.versions-list tr.download td {
-    padding-bottom: 0.6em;
-}
-
-.versions-list li span.version {
-    display: inline-block;
-    width: 8em;
 }
 
 .versions-list li span.reldate {
@@ -167,7 +207,18 @@ div#download-stable h1, div#download-dev h1, div#download-source h1 {
 
 .download-btn {
     margin-top: 1.0em;
-    text-align: center;
+}
+
+.download-btn .btn {
+    text-indent: -0.75em;
+    padding-left: 3.2em;
+}
+
+.download-btn .main-download-icon{
+    font-size: 1.4em;
+    line-height: 1em;
+    display: inline-block;
+    margin-right: 0.34em;
 }
 
 .fb-like {
@@ -181,11 +232,6 @@ div#download-stable h1, div#download-dev h1, div#download-source h1 {
     display: inline-block;
 }
 
-#sshot-carousel {
-    box-shadow: 0 0 6px #222222;
-    margin-bottom: 0;
-}
-
 .hero-unit .requirements {
     font-size: 0.9em;
     line-height: 1.4em;
@@ -193,8 +239,6 @@ div#download-stable h1, div#download-dev h1, div#download-source h1 {
 
 li.faq-cat {
     text-transform: uppercase;
-    font-size: 0.9em;
-    margin-top: 0.7em;
 }
 
 li.faq-title {
@@ -246,7 +290,6 @@ html[dir="rtl"] .nav .flag {
 
 .ratings-expl ul {
     list-style: none;
-    margin-top: 1.6em;
 }
 
 .ratings-expl li {
@@ -263,9 +306,9 @@ html[dir="rtl"] .nav .flag {
     font-size: 0.85em;
 }
 
-div.realign.ratings-stats {
-    margin-top: 3.1em;
-}
+/*div.realign.ratings-stats {*/
+    /*margin-top: 3.1em;*/
+/*}*/
 
 .ratings-stats .progress-bar {
     height: 12px;
@@ -276,22 +319,8 @@ div.realign.ratings-stats {
     margin-bottom: 6px;
 }
 
-.compat-list {
-    width: 100%;
-    margin: 0 auto;
-    text-align: center;
-}
-
 .compat-list tbody tr {
     vertical-align: center;
-}
-
-.compat-list tbody tr:nth-child(2n) {
-    background-color: #eee;
-}
-
-.compat-list tbody tr:nth-child(2n+1) {
-    background-color: #fff;
 }
 
 .compat-list th.category, .compat-list td.category {
@@ -302,6 +331,8 @@ div.realign.ratings-stats {
     width: 10%;
     margin-top: 1px;
     margin-bottom: 1px;
+    padding-left: 0;
+    padding-right: 0;
 }
 
 .compat-list td.banner div.bnr {
@@ -341,27 +372,6 @@ div.realign.ratings-stats {
     line-height: 24px;
 }
 
-.col-row {
-    overflow: hidden;
-}
-
-.col-row .col {
-    margin-bottom: -99999px;
-    padding-bottom: 99999px;
-    padding-left: 1em;
-    background-color:#f5f5f5;
-    border: 0;
-    border-radius: 0;
-}
-
-.ratings-expl h3 {
-    margin-left: 35px;
-}
-
-.ratings-expl, .ratings-stats {
-    margin-bottom: 20px;
-}
-
 .back-link {
     font-weight: bold;
 }
@@ -376,15 +386,9 @@ img.fp-sshot {
     width: 100%;
 }
 
-div.sshot-row {
-    padding-left: 0.9em;
-    padding-right: 0.9em;
-    padding-bottom: 1em;
-}
-
 div.sshot-col {
+    margin-top: 1rem;
     text-align: center;
-    padding: 0.3em;
 }
 
 p.intro {
@@ -392,11 +396,46 @@ p.intro {
     font-size: 14px;
 }
 
-.container div.jumbotron.my-hero {
-    padding-left: 2em;
-    padding-right: 2em;
-    padding-top: 1em;
-    padding-bottom: 1em;
+div.jumbotron.my-hero {
+    position: relative;
+    background-color: #000;
+}
+
+div.jumbotron.my-hero .container:before{
+    content: '';
+    display: inline-block;
+    height: 100%;
+    vertical-align: middle;
+    margin-right: -0.25em;
+}
+
+div.jumbotron.my-hero .main-header {
+    position: relative;
+    width: 99.5%;
+    max-width: 50rem;
+    padding: 1rem 2rem;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+div.jumbotron.my-hero .carousel-item {
+    height: 32rem;
+    min-height: 40vmin;
+    text-align: center;
+    overflow: hidden;
+    background-color: #000;
+}
+
+div.jumbotron.my-hero .carousel-item img{
+    min-height: 100%;
+    min-width: 100%;
+    opacity: 0.2;
+}
+
+div.jumbotron.my-hero .container {
+    position: relative;
+    margin-top: -32rem;
+    height: 32rem;
 }
 
 div.my-hero h3 {
@@ -425,16 +464,15 @@ a.navbar-logo {
 }
 
 .my-hero h1.title {
-    font-size: 40px;
-    background-image: url("../img/logo-blue.png");
-    background-repeat: no-repeat;
+    background: url("../img/logo-blue.png") no-repeat;
     background-position-y: center;
     background-size: 100px;
     padding-left: 120px;
-    padding-top: 10px;
+    padding-top: 2px;
     padding-bottom: 10px;
     margin-top: 10px;
     margin-bottom: 20px;
+    font-variant: small-caps;
 }
 
 .page-header {
@@ -458,10 +496,6 @@ a.navbar-logo {
         white-space: normal;
     }
 
-    #navbar-dolphin {
-        font-size: 0.9em;
-    }
-
     #navbar-dolphin .container {
         max-width: 1100px;
     }
@@ -471,20 +505,20 @@ a.navbar-logo {
     }
 }
 
-@media (max-width: 1000px) {
-    #navbar-dolphin {
-        font-size: 0.7em;
-    }
+/*@media (max-width: 1000px) {*/
+    /*#navbar-dolphin {*/
+        /*font-size: 0.7em;*/
+    /*}*/
 
-    #navbar-dolphin .container {
-        width: 100%;
-        max-width: 950px;
-    }
+    /*#navbar-dolphin .container {*/
+        /*width: 100%;*/
+        /*max-width: 950px;*/
+    /*}*/
 
-    #navbar-dolphin .nav > li > a {
-        padding: 15px 10px 15px 10px;
-    }
-}
+    /*#navbar-dolphin .nav > li > a {*/
+        /*padding: 15px 10px 15px 10px;*/
+    /*}*/
+/*}*/
 
 /* Blog */
 p.seemore {
@@ -664,6 +698,7 @@ div.draft-warning {
     border-radius: 4px;
     padding: 2px 0;
     background: #FF6600;
+    line-height: 20px;
 }
 .rss-tag:hover {
     color: white;

--- a/dolweb/templates/_base.html
+++ b/dolweb/templates/_base.html
@@ -27,9 +27,8 @@
             {% endif %}
         {% endfor %}
 
-        <link href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.min.css" rel="stylesheet">
-        <link href="{% static "css/bootstrap.min.css" %}" rel="stylesheet">
-        <link href="{% static "css/bootstrap-theme.min.css" %}" rel="stylesheet">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" integrity="sha384-tKLJeE1ALTUwtXlaGjJYM3sejfssWdAaWR2s97axw4xkiAdMzQjtOjgcyw0Y50KU" crossorigin="anonymous">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU" crossorigin="anonymous">
         <link href="{% static "css/dolphin.css" %}" rel="stylesheet">
         <link href="{% static "sprites/nav.css" %}" rel="stylesheet">
         {% block "extracss" %}
@@ -90,35 +89,40 @@
     <body>
         {% block "bodystart" %}{% endblock %}
 
-        <div id="navbar-dolphin" class="navbar navbar-inverse">
+        <nav id="navbar-dolphin" class="navbar navbar-expand-lg navbar-dark bg-dark">
             <div class="container">
-                <div class="navbar-header">
-                    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-                        <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
-                    </button>
-                    <a class="navbar-logo" href="{% url 'home' %}"><img src="{% static "img/logo.png" %}" height="32" alt="{% trans "Dolphin Emulator" %}"></a>
-                </div>
-                <div class="navbar-collapse collapse">
-                    <ul class="nav navbar-nav pull-left">
-                        <li><a href="{% url 'downloads_index' %}">{% trans "Download" %}</a></li>
-                        <li><a href="{% url 'zinnia:entry_archive_index' %}">{% trans "Blog" %}</a></li>
-                        <li><a href="{% url 'media_all' %}">{% trans "Screenshots" %}</a></li>
-                        <li><a href="{% url 'docs_faq' %}">{% trans "FAQ" %}</a></li>
-                        <li><a href="{% url 'docs_guides_index' %}">{% trans "Guides" %}</a></li>
-                        <li><a href="{% url 'compat_index' %}">{% trans "Compatibility" %}</a></li>
-                        <li><a href="{{ FORUM_URL }}">{% trans "Forum" %}</a></li>
-                        <li><a href="{{ WIKI_URL }}">{% trans "Wiki" %}</a></li>
-                        <li><a href="{{ GIT_BROWSE_URL }}">{% trans "Code" %}</a></li>
+                <a class="navbar-brand" href="{% url 'home' %}">
+                    <img src="{% static "img/logo.png" %}" height="32" alt="{% trans "Dolphin Emulator" %}" class="d-inline-block align-text-top">
+                </a>
+                <button class="navbar-toggler pull-right" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-nav" aria-controls="navbar-nav" aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+                <div class="navbar-collapse collapse" id="navbar-nav">
+                    <ul class="navbar-nav me-auto">
+                        <li class="nav-item"><a class="nav-link" href="{% url 'downloads_index' %}">{% trans "Download" %}</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{% url 'zinnia:entry_archive_index' %}">{% trans "Blog" %}</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{% url 'media_all' %}">{% trans "Screenshots" %}</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{% url 'docs_faq' %}">{% trans "FAQ" %}</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{% url 'docs_guides_index' %}">{% trans "Guides" %}</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{% url 'compat_index' %}">{% trans "Compatibility" %}</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{{ FORUM_URL }}">{% trans "Forum" %}</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{{ WIKI_URL }}">{% trans "Wiki" %}</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{{ GIT_BROWSE_URL }}">{% trans "Code" %}</a></li>
                     </ul>
-                    <ul class="nav navbar-nav pull-right">
-                        <li class="dropdown">
-                        <a href="#" class="dropdown-toggle" data-toggle="dropdown"><div class="flag curr-flag sprite-nav-{{ LANGUAGE_CODE|short }}"></div> <span>{{ LANGUAGE_CODE|langname }}</span> <b class="caret"></b></a>
-                            <ul class="dropdown-menu">
+                    <ul class="nav navbar-nav mb-2 mb-lg-0 float-lg-end">
+                        <li class="nav-item dropdown">
+                            <a href="#" class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                <div class="flag curr-flag sprite-nav-{{ LANGUAGE_CODE|short }}"></div> <span>{{ LANGUAGE_CODE|langname }}</span> <b class="caret"></b>
+                            </a>
+                            <ul class="dropdown-menu dropdown-menu-dark dropdown-menu-end" aria-labelledby="navbarDropdown">
                             {% for langshort, langname in LANGUAGES %}
                                 {% if langshort != LANGUAGE_CODE|short %}
-                                <li><a href="//{{ langshort|to_subdomain }}{{ request.path }}?nocr=true"><div class="flag sprite-nav-{{ langshort }}"></div><span dir="{{ langshort|langdir }}">{{ langname }}</span></a></li>
+                                <li>
+                                    <a href="//{{ langshort|to_subdomain }}{{ request.path }}?nocr=true" class="dropdown-item">
+                                        <div class="flag sprite-nav-{{ langshort }}"></div>
+                                        <span dir="{{ langshort|langdir }}">{{ langname }}</span>
+                                    </a>
+                                </li>
                                 {% endif %}
                             {% endfor %}
                             </ul>
@@ -126,7 +130,7 @@
                     </ul>
                 </div>
             </div>
-        </div>
+        </nav>
 
         {% block "outerbody" %}
         {% endblock %}
@@ -144,6 +148,29 @@
             {% endblock %}
         </div>
 
+        <div class="modal fade" id="lightbox-modal" tabindex="-1" aria-labelledby="lightbox-modal-label" aria-hidden="true">
+            <div class="modal-dialog modal-xl modal-fullscreen-sm-down">
+                <div class="modal-content overflow-hidden">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="lightbox-modal-label">Image title</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body p-0">
+                        <div class="position-absolute top-0 backdrop">
+                            <img class="backdrop-img position-absolute top-50 start-50 translate-middle">
+                        </div>
+                        <div class="d-flex align-items-center h-100">
+                            <img class="img-fluid lightbox-img">
+                        </div>
+                        <div class="arrow-overlay">
+                            <a href="#" class="arrow previous d-none" aria-label="Previous Image"><i class="bi bi-caret-left-fill"></i></a>
+                            <a href="#" class="arrow next d-none" aria-label="Next Image"><i class="bi bi-caret-right-fill"></i></a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <footer>
         <p class="footer-text">
             {% trans "&copy; Dolphin Emulator Project" %} -
@@ -153,7 +180,93 @@
         </footer>
 
         <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
-        <script src="{% static "js/bootstrap.min.js" %}"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-/bQdsTh/da6pkI1MST/rWKFNjaCP5gBSY4sEBT38Q/9RBh9AH40zEOg7Hlq2THRZ" crossorigin="anonymous"></script>
+        <script type="text/javascript">
+            // Lightbox
+            var lightboxModal = document.getElementById('lightbox-modal');
+            var lightboxModalPrev = lightboxModal.querySelector(".previous");
+            var lightboxModalNext = lightboxModal.querySelector(".next");
+            var modalTitle = lightboxModal.querySelector('.modal-title');
+            var modalImage = lightboxModal.querySelector('.modal-body img.lightbox-img');
+            var modalBackdrop = lightboxModal.querySelector('.modal-body img.backdrop-img');
+
+            var prevElem = null;
+            var nextElem = null;
+
+            lightboxModal.addEventListener('show.bs.modal', function (event) {
+                // Button that triggered the modal
+                var button = event.relatedTarget;
+                loadLightbox(button);
+            });
+
+            lightboxModalPrev.addEventListener('click', function (event) {
+                if(prevElem){
+                    loadLightbox(prevElem);
+                }
+            });
+
+            lightboxModalNext.addEventListener('click', function (event) {
+                if(nextElem){
+                    loadLightbox(nextElem);
+                }
+            });
+
+            function loadLightbox(eventElem) {
+                // Is part of a gallery?
+                var galleryElem = eventElem.closest("div[data-gallery]");
+                if(galleryElem){
+                    // No real reason to get the gallery name right now, but it's there if needed
+                    // var galleryName = galleryElem.getAttribute("data-gallery");
+
+                    // Select all other nodes in this gallery
+                    var galleryItems = galleryElem.querySelectorAll("a[data-toggle='lightbox']");
+
+                    // Get the nodes as an array to get the index
+                    var nodes = Array.prototype.slice.call(galleryItems);
+                    var currentIndex = nodes.indexOf(eventElem);
+
+                    // Get previous element
+                    if(currentIndex - 1 > -1) {
+                        prevElem = galleryItems[currentIndex - 1];
+                    }else{
+                        prevElem = null;
+                    }
+
+                    // Get next element
+                    if(currentIndex + 1 < galleryItems.length) {
+                        nextElem = galleryItems[currentIndex + 1];
+                    }else{
+                        nextElem = null
+                    }
+
+                    // Add prev/next arrows if needed
+                    if(prevElem) {
+                        lightboxModalPrev.classList.remove("d-none");
+                    }else{
+                        lightboxModalPrev.classList.add("d-none");
+                    }
+                    if(nextElem) {
+                        lightboxModalNext.classList.remove("d-none");
+                    }else{
+                        lightboxModalNext.classList.add("d-none");
+                    }
+                }else{
+                    // Remove prev/next arrows
+                    lightboxModalPrev.classList.add("d-none");
+                    lightboxModalNext.classList.add("d-none");
+                    prevElem = null;
+                    nextElem = null;
+                }
+
+                // Extract info from data attributes
+                var imgTitle = eventElem.getAttribute('data-title');
+                var bigImgSrc = eventElem.getAttribute('data-src');
+                // Update the modal's content.
+                modalTitle.textContent = imgTitle;
+                modalImage.src = bigImgSrc;
+                modalBackdrop.src = bigImgSrc;
+            }
+        </script>
         {% block "extrajs" %}
         {% endblock %}
     </body>


### PR DESCRIPTION
First PR here, so go easy on me. 😉 

This one's fairly self-explanatory. I upgraded the Bootrstrap version from 3 to 5.1, attempting to preserve the general layout/content while making things look more modern.

Notable changes:
- Removed the dependency on FontAwesome 3.2.1 since Bootstrap 5 has their own icons.
- Removed the dependency on ekko lightbox as it was no longer being maintained beyond Bootstrap 4.x
  - In it's place is a simple lightbox replacement made with vanilla js. It should have all the existing functionality, though not the complete functionality of ekko lightbox. As a tradeoff, it is much more mobile-friendly
- Made compat more mobile-friendly, though on _very_ small devices it may still require some horizontal scrolling.
- Updated the homepage banner to be full-width and behind the hero text. Personally I think the look is an improvement, but I understand this may be a matter of taste. 😛 

Other things to mention: I'm not sure if there's any reason to have the jQuery dependency anymore since Bootstrap 5.x no longer requires it and ekko lightbox is gone. I left it just in case, but if those were the only places it was used, perhaps that should be removed as well to reduce page load times.

Pretty confident I got all the pages that needed attention, but I may have missed something so let me know if I need to revisit this.

_Side note: CTRL/CtrlSTheWorld/GuitarBro all are me, just in case there's any confusion. Sorry about the inconsistency across git/github._