### PR TITLE
update: add release date

### DIFF
--- a/dolweb/update/views.py
+++ b/dolweb/update/views.py
@@ -93,6 +93,7 @@ def latest(request, track):
         artifacts.append({'system': art.target_system, 'url': art.url})
     data = {
         'shortrev': version.shortrev,
+        'date': version.date,
         'hash': version.hash,
         'changelog_html': changelog_html,
         'artifacts': artifacts


### PR DESCRIPTION
I recently automated updates for the [flathub](https://github.com/flathub/org.DolphinEmu.dolphin-emu/pulls?q=is%3Apr+is%3Aclosed) using json from the https://dolphin-emu.org/update/latest/beta endpoint.

Would it be possible to add a release date to this data?

Is this the correct value to use?