### PR TITLE
Apply wiki styling to h1-h6, not just h2

### DIFF
--- a/dolweb/static/css/wiki.css
+++ b/dolweb/static/css/wiki.css
@@ -33,12 +33,34 @@
     margin: 0 0 0 2em;
 }
 
+#mw-content-text h1 {
+    padding-top: .5em;
+    padding-bottom: .17em;
+    border-bottom: 1px solid #aaa;
+    font-size: 180%;
+    margin-bottom: .6em;
+}
+
 #mw-content-text h2 {
     padding-top: .5em;
     padding-bottom: .17em;
     border-bottom: 1px solid #aaa;
     font-size: 150%;
     margin-bottom: .6em;
+}
+
+#mw-content-text h3 {
+    font-size: 120%;
+    font-weight: bold;
+}
+
+#mw-content-text h4 {
+    font-size: 100%;
+    font-weight: bold;
+}
+
+#mw-content-text h5, #mw-content-text h6 {
+    font-size: 100%;
 }
 
 #toc h2, .toc h2 {


### PR DESCRIPTION
This fixes h3 being bigger than h2, which was particularly obvious on [the Wii Network Guide page](https://dolphin-emu.org/docs/guides/wii-network-guide/).

<details><summary>Screenshots</summary>

MediaWiki:

![image](https://user-images.githubusercontent.com/8334194/196055660-e5a59c48-7cb6-4099-b189-ffa6d658396b.png)

Site before:

![image](https://user-images.githubusercontent.com/8334194/196055665-755ddcbb-769c-4086-9fb4-6b4ad6301d07.png)

Site after:

![image](https://user-images.githubusercontent.com/8334194/196055669-516e6f76-f5cd-4437-89aa-89eb38955f02.png)
</details>

Tested using Firefox's style editor and inspect element to replace the text. Based on [this](https://github.com/wikimedia/Vector/blob/b69cd0fe4ac21fe206b887cbb4c2c336f72fe158/resources/common/typography.less#L40-L140) and [this](https://github.com/wikimedia/Vector/blob/ca3fe05c5ec0350d2caf8f4c00dcd51fe5599f89/resources/common/variables.less#L47-L55) from the MediaWiki vector skin.