### PR TITLE
rename every instance of "stable" to "legacy"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Use of Git
 ----------
 
 The Git branch deployed on the main website instance (https://dolphin-emu.org/)
-is the ``stable`` branch. When we do large scale changes that require staging
+is the ``legacy`` branch. When we do large scale changes that require staging
 and more testing, we work in the ``master`` branch, which is deployed on a
 special website instance (https://dev.dolphin-emu.org/). Note that these two
 website instances share their database - as such, database schema changes

--- a/TODO
+++ b/TODO
@@ -3,7 +3,7 @@
 * Provide some fake data sets to use as initial database contents.
 
 * Download UI: too confusing for users, way too many versions displayed on the
-  downloads page. Simplify the view with two side by side options: stable or
+  downloads page. Simplify the view with two side by side options: legacy or
   latest. Explain the benefits. Have links to a more complete downloads page
   with older versions.
 

--- a/dolweb/downloads/templates/downloads-index.html
+++ b/dolweb/downloads/templates/downloads-index.html
@@ -29,7 +29,7 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 
 <div id="download-beta">
 <h1>{% trans "Beta versions" %}</h1>
-    
+
 <div class="alert alert-info">{% blocktrans %}
     <p>Beta versions are released every month, usually accompanied by a <em>Progress Report</em>
     article. Use the latest beta version if you prefer stability over the newest features in the
@@ -46,7 +46,7 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 
 <div id="download-dev">
 <h1>{% trans "Development versions" %}</h1>
-    
+
 <div class="alert alert-info">
     <p>{% blocktrans %}Development versions are released every time a developer makes a change to
     Dolphin, several times every day! Using development versions enables you to
@@ -77,18 +77,18 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 </script>
 </div>
 
-<div id="download-stable">
-<h1>{% trans "Stable versions" %}</h2>
+<div id="download-legacy">
+<h1>{% trans "Legacy versions" %}</h2>
 
 {# TODO: Update when 6.0 is released #}
 <div class="alert alert-warning">{% blocktrans %}
-    The stable versions below are years out of date and missing countless features and bug fixes.
+    The legacy versions below are years out of date and missing countless features and bug fixes.
     <a href="#download-beta">Beta</a> or <a href="#download-dev">development</a> versions are a
-    better choice for almost all users; the stable versions should only be used if you have
+    better choice for almost all users; the legacy versions should only be used if you have
     a specific need for them.
 {% endblocktrans %}</div>
 
-<table class="versions-list stable-versions">
+<table class="versions-list legacy-versions">
     <tbody>
     {% for ver in releases %}
         <tr class="infos">
@@ -104,7 +104,7 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
         </tr>
         </li>
     {% empty %}
-        <tr><td colspan="2"><em>{% trans "No stable release yet" %}</em></td></tr>
+        <tr><td colspan="2"><em>{% trans "No legacy release yet" %}</em></td></tr>
     {% endfor %}
     </tbody>
 </table>
@@ -113,7 +113,7 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 <div id="other-linux">
     <h1>{% trans "Linux distributions" %}</h1>
     <p>{% blocktrans %}Ubuntu users can install a PPA
-    for development and stable versions of Dolphin here: <a href="https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu">Installing Dolphin</a>
+    for development and legacy versions of Dolphin here: <a href="https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu">Installing Dolphin</a>
     {% endblocktrans %}</p>
     <p>{% blocktrans %}Users of other Linux distributions can look here to compile Dolphin: <a href="https://wiki.dolphin-emu.org/index.php?title=Building_Dolphin_on_Linux">Building Dolphin on Linux</a>
     {% endblocktrans %}</p>

--- a/dolweb/locale/ar/LC_MESSAGES/django.po
+++ b/dolweb/locale/ar/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # mansoor <asseryma@hotmail.com>, 2016,2018
 # Mosaab Alzoubi <moceap@hotmail.com>, 2013
@@ -599,20 +599,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "الإصدارات المُستقرّة"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "لا يوجد إصدارات مُستقرّة"
 
 #: downloads/templates/downloads-index.html:114
@@ -622,7 +622,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/ast/LC_MESSAGES/django.po
+++ b/dolweb/locale/ast/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # enolp <enolp@softastur.org>, 2020,2022
 # Ḷḷumex03, 2013-2014
@@ -593,20 +593,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Versiones estables"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Entá nun hai versiones estables"
 
 #: downloads/templates/downloads-index.html:114
@@ -616,7 +616,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/bg/LC_MESSAGES/django.po
+++ b/dolweb/locale/bg/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -524,26 +524,26 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:63
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:65
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:87
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:94
@@ -553,7 +553,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:95
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/ca/LC_MESSAGES/django.po
+++ b/dolweb/locale/ca/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Gerard Nesta <gerardnll@gmail.com>, 2021
 # Puniasterus <puniasterus@gmail.com>, 2013-2015
@@ -592,20 +592,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Versions estables "
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Encara no hi ha una versió estable"
 
 #: downloads/templates/downloads-index.html:114
@@ -615,7 +615,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/cs/LC_MESSAGES/django.po
+++ b/dolweb/locale/cs/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Zbyněk Schwarz <zbynek.schwarz@gmail.com>, 2013-2015
 msgid ""
@@ -594,20 +594,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Stabilní verze"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Zatím žádná stabilní verze"
 
 #: downloads/templates/downloads-index.html:114
@@ -617,7 +617,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/cy/LC_MESSAGES/django.po
+++ b/dolweb/locale/cy/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Llyr Ceredig <llyrceredig@gmail.com>, 2013-2014
 msgid ""
@@ -594,20 +594,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Fersiynau cadarn"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Dim fersiwn cadarn ar hyn o bryd"
 
 #: downloads/templates/downloads-index.html:114
@@ -617,7 +617,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/da/LC_MESSAGES/django.po
+++ b/dolweb/locale/da/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # HiKaroline <hitherekaroline@gmail.com>, 2016
 # Lars Lyngby <larslyngby@hotmail.com>, 2020
@@ -593,20 +593,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Stabile versioner"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Ingen stabil udgivelse endnu"
 
 #: downloads/templates/downloads-index.html:114
@@ -616,7 +616,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/da_DK/LC_MESSAGES/django.po
+++ b/dolweb/locale/da_DK/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Karoline Rasmussen <hitherekaroline@gmail.com>, 2016
 # Patrick Larsen <hatsen2000@gmail.com>, 2013,2015
@@ -527,7 +527,7 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
@@ -540,24 +540,24 @@ msgstr "Udgivelseskandidat versioner"
 #: downloads/templates/downloads-index.html:51
 msgid ""
 "\n"
-"    Release candidate versions are released to test an upcoming stable release of\n"
-"    Dolphin. They are generally more stable than the Development versions, but may still have known bugs.\n"
+"    Release candidate versions are released to test an upcoming legacy release of\n"
+"    Dolphin. They are generally more legacy than the Development versions, but may still have known bugs.\n"
 msgstr "\nUdgivelseskandidat versioner udgives for at teste en kommende stabil udgivelse af Dolphin. De er generelt mere stabile end udviklerversioner, men kan stadig indeholde kendte fejl.\n"
 
 #: downloads/templates/downloads-index.html:74
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Stabile versioner"
 
 #: downloads/templates/downloads-index.html:76
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr "\nStabile versioner er udgivet efter en hel del test for at sikre at emulationsydelse og stabilitet. Men siden de udgives mindre ofte kan de være uddateret og mangle nye funktioner.\n"
 
 #: downloads/templates/downloads-index.html:98
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Ingen stabil udgivelse endnu"
 
 #: downloads/templates/downloads-index.html:105
@@ -567,7 +567,7 @@ msgstr "Ældre Ubuntu (< 15.04) og brugere af andre Linux distributioner"
 #: downloads/templates/downloads-index.html:106
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr "Ubuntu 14.10 og andre brugere can installere en PPA\nfor udviklings og stabile versioner af dolphin her: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installation af Dolphin</a>"
 

--- a/dolweb/locale/de/LC_MESSAGES/django.po
+++ b/dolweb/locale/de/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Danny Krug <Dan_krug@gmx.de>, 2013
 # DefenderX <darkmodx@gmail.com>, 2013
@@ -607,20 +607,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Stabile Versionen"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Noch keine stabile Version verfügbar"
 
 #: downloads/templates/downloads-index.html:114
@@ -630,7 +630,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/el/LC_MESSAGES/django.po
+++ b/dolweb/locale/el/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # firespin, 2014
 # link_to_the_past <kostamarino@gmail.com>, 2013-2015,2018
@@ -592,20 +592,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Σταθερές εκδόσεις"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Δεν έχει εκδοθεί σταθερή έκδοση ακόμα"
 
 #: downloads/templates/downloads-index.html:114
@@ -615,7 +615,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/eo/LC_MESSAGES/django.po
+++ b/dolweb/locale/eo/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -524,26 +524,26 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:63
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:65
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:87
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:94
@@ -553,7 +553,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:95
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/es/LC_MESSAGES/django.po
+++ b/dolweb/locale/es/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Petiso_Carambanal <diegoae@gmail.com>, 2013-2015,2021
 # Jambi <jlarrondobunop@yahoo.es>, 2015
@@ -600,20 +600,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Versiones estables"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Todavía no hay versiones estables"
 
 #: downloads/templates/downloads-index.html:114
@@ -623,7 +623,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/fa/LC_MESSAGES/django.po
+++ b/dolweb/locale/fa/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -524,26 +524,26 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:63
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "نسخه های پایدار"
 
 #: downloads/templates/downloads-index.html:65
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:87
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "هنوز نسخه پایداری وجود ندارد"
 
 #: downloads/templates/downloads-index.html:94
@@ -553,7 +553,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:95
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/fi/LC_MESSAGES/django.po
+++ b/dolweb/locale/fi/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -524,26 +524,26 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:63
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:65
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:87
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:94
@@ -553,7 +553,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:95
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/fr/LC_MESSAGES/django.po
+++ b/dolweb/locale/fr/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Pierre Bourdon <delroth@gmail.com>, 2013
 # Pascal <pascal2j-language@yahoo.com>, 2014-2015,2017-2019,2023
@@ -594,21 +594,21 @@ msgid ""
 msgstr "Les versions de développement pour Windows <b>requièrent</b> l'installation du <a href=\"https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads\">redistribuable 64-bit de Visual Studio 2022</a>."
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Versions stables"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr "\nLes versions stables ci-dessous ont plusieurs années, ne sont plus à jour, et il leur manquent de nombreuses fonctionnalités et corrections de bugs.\nLes versions <a href=\"#download-beta\">Bêta</a> ou de <a href=\"#download-dev\">développement</a> sont recommandées\npour la plupart des utilisateurs ; les versions stables ne devraient être utilisées que si vous avez un besoin spécifique.\n"
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
-msgstr "Pas de version stable disponible"
+msgid "No legacy release yet"
+msgstr "Pas de version legacy disponible"
 
 #: downloads/templates/downloads-index.html:114
 msgid "Linux distributions"
@@ -617,7 +617,7 @@ msgstr "Distributions Linux"
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr "Les utilisateurs d'Ubuntu peuvent installer un PPA\npour les versions de développement et stables de Dolphin ici : <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installer Dolphin</a>"
 

--- a/dolweb/locale/ga/LC_MESSAGES/django.po
+++ b/dolweb/locale/ga/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -527,26 +527,26 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:63
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:65
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:87
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:94
@@ -556,7 +556,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:95
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/gl/LC_MESSAGES/django.po
+++ b/dolweb/locale/gl/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # mandruis <manuiglesias96@yahoo.es>, 2016
 # Rubén <feiticeiro2010@hotmail.es>, 2014,2016
@@ -592,20 +592,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Versións estables"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Aínda non hai versións estables"
 
 #: downloads/templates/downloads-index.html:114
@@ -615,7 +615,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/he/LC_MESSAGES/django.po
+++ b/dolweb/locale/he/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Idan bvcs <idan062@gmail.com>, 2017
 msgid ""
@@ -594,20 +594,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:114
@@ -617,7 +617,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/hi/LC_MESSAGES/django.po
+++ b/dolweb/locale/hi/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Ayush Arora <aviarora24@gmail.com>, 2013
 msgid ""
@@ -525,26 +525,26 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:63
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:65
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:87
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:94
@@ -554,7 +554,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:95
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/hi_IN/LC_MESSAGES/django.po
+++ b/dolweb/locale/hi_IN/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Ayush Arora <aviarora24@gmail.com>, 2013
 msgid ""
@@ -525,7 +525,7 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
@@ -538,24 +538,24 @@ msgstr ""
 #: downloads/templates/downloads-index.html:51
 msgid ""
 "\n"
-"    Release candidate versions are released to test an upcoming stable release of\n"
-"    Dolphin. They are generally more stable than the Development versions, but may still have known bugs.\n"
+"    Release candidate versions are released to test an upcoming legacy release of\n"
+"    Dolphin. They are generally more legacy than the Development versions, but may still have known bugs.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:74
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:76
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:98
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:105
@@ -565,7 +565,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:106
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/hr/LC_MESSAGES/django.po
+++ b/dolweb/locale/hr/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Alberto Poljak <albertopoljak@gmail.com>, 2013-2014
 # Poljak2 <nbvfrp@gmail.com>, 2013
@@ -593,20 +593,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Stabilne verzije"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Stabilna verzije nije izdana"
 
 #: downloads/templates/downloads-index.html:114
@@ -616,7 +616,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/hu/LC_MESSAGES/django.po
+++ b/dolweb/locale/hu/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Delirious <delirious@freemail.hu>, 2013
 # Delirious <delirious@freemail.hu>, 2013
@@ -592,20 +592,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Stabil verziók"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Nincs még stabil kiadás"
 
 #: downloads/templates/downloads-index.html:114
@@ -615,7 +615,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/id/LC_MESSAGES/django.po
+++ b/dolweb/locale/id/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -523,26 +523,26 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:63
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:65
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:87
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:94
@@ -552,7 +552,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:95
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/is/LC_MESSAGES/django.po
+++ b/dolweb/locale/is/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -524,26 +524,26 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:63
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:65
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:87
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:94
@@ -553,7 +553,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:95
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/it/LC_MESSAGES/django.po
+++ b/dolweb/locale/it/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Mewster <mewster@libero.it>, 2013-2015,2017,2023
 # Mewster <mewster@libero.it>, 2013
@@ -593,20 +593,20 @@ msgid ""
 msgstr "Le versioni di sviluppo per Windows <b>richiedono</b> l'installazione dei <a href=\"https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads\">redistribuibili Visual C++ 64-bit per Visual Studio 2022</a>."
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Versioni stabili"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr "\n    Le versioni stabili qui sotto sono vecchie di anni e mancano di innumerevoli funzionalità e correzioni.\n    Le versioni <a href=\"#download-beta\">beta</a> o <a href=\"#download-dev\">di sviluppo</a> sono una scelta migliore per la maggior parte degli utente; le versioni stabili dovrebbero\n    essere usate solo se hai un bisogno specifico.\n"
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Non sono disponibili versioni stabili"
 
 #: downloads/templates/downloads-index.html:114
@@ -616,7 +616,7 @@ msgstr "Distribuzioni Linux"
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr "Utenti Ubuntu possono installare un PPA\n    per le versioni in sviluppo e stabili di Dolphin qui: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>"
 

--- a/dolweb/locale/ja/LC_MESSAGES/django.po
+++ b/dolweb/locale/ja/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # DanbSky <danbsky@live.jp>, 2015
 # DanbSky <danbsky@live.jp>, 2013
@@ -591,20 +591,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "安定版"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "現在、安定版のリリースはありません。"
 
 #: downloads/templates/downloads-index.html:114
@@ -614,7 +614,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/ko/LC_MESSAGES/django.po
+++ b/dolweb/locale/ko/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Siegfried, 2013-2016
 # its take <bexco2010@gmail.com>, 2016
@@ -591,20 +591,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "안정된 버전"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "아직 안정된 출시 버전이 없음"
 
 #: downloads/templates/downloads-index.html:114
@@ -614,7 +614,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/lv/LC_MESSAGES/django.po
+++ b/dolweb/locale/lv/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -525,26 +525,26 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:63
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:65
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:87
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:94
@@ -554,7 +554,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:95
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/ms/LC_MESSAGES/django.po
+++ b/dolweb/locale/ms/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -587,20 +587,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Versi stabil"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Tiada keluaran stabil lagi"
 
 #: downloads/templates/downloads-index.html:114
@@ -610,7 +610,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/ms_MY/LC_MESSAGES/django.po
+++ b/dolweb/locale/ms_MY/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # abuyop <abuyop@gmail.com>, 2013-2015
 msgid ""
@@ -524,7 +524,7 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
@@ -537,24 +537,24 @@ msgstr "Versi Calon Keluaran"
 #: downloads/templates/downloads-index.html:51
 msgid ""
 "\n"
-"    Release candidate versions are released to test an upcoming stable release of\n"
-"    Dolphin. They are generally more stable than the Development versions, but may still have known bugs.\n"
+"    Release candidate versions are released to test an upcoming legacy release of\n"
+"    Dolphin. They are generally more legacy than the Development versions, but may still have known bugs.\n"
 msgstr "\nVersi calon keluar dikeluarkan untuk menguji keluaran stabil akan datang\nDolphin. Ia umumnya lebih stabil berbanding versi Pembangunan, tetapi masih\nterdapat pepijat yang dikenalpasti.\n"
 
 #: downloads/templates/downloads-index.html:74
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Versi stabil"
 
 #: downloads/templates/downloads-index.html:76
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr "\nVersi stabil dikeluarkan selepas banyak pengujian untuk memastikan\nprestasi emulasi dan kestabilan. Namun, semenjak ia kurang dikeluarkan,\nia mungkin telah lapuk dan kekurangan beberapa fitur baru.\n"
 
 #: downloads/templates/downloads-index.html:98
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Tiada keluaran stabil lagi"
 
 #: downloads/templates/downloads-index.html:105
@@ -564,7 +564,7 @@ msgstr "Ubuntu lebih lama (< 15.04) dan pengguna lain-lain distribusi Linux"
 #: downloads/templates/downloads-index.html:106
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr "Pengguna Ubuntu 14.10 dan lebih lama boleh memasang PPA \n    untuk versi pembangunan dan stabil Dolphin di sini: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Pemasangan Dolphin</a>\n    "
 

--- a/dolweb/locale/nb/LC_MESSAGES/django.po
+++ b/dolweb/locale/nb/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Allan Nordhøy <epost@anotheragency.no>, 2014
 # Allan Nordhøy <epost@anotheragency.no>, 2015-2016
@@ -596,20 +596,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Stabile versjoner"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Ingen stabile utgivelser enda"
 
 #: downloads/templates/downloads-index.html:114
@@ -619,7 +619,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/nl/LC_MESSAGES/django.po
+++ b/dolweb/locale/nl/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Boris Peeters, 2019
 # Garteal <garteal@gmail.com>, 2013-2014,2016
@@ -594,20 +594,20 @@ msgid ""
 msgstr "Voor de Windows ontwikkelings-versies <b>moet</b> de <a href=\"https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads\">64-bit Visual C++ redistributable voor Visual Studio 2022</a> worden geïnstalleerd."
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Stabiele-versies"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr "\n De stabiele versies hieronder zijn jaren verouderd en missen talloze functies en bugfixes.\n<a href=\"#download-beta\">Beta-</a> of <a href=\"#download-dev\">ontwikkelings-versies</a> zijn een\nbetere keuze voor bijna alle gebruikers; de stabiele versies moet u alleen gebruiken als u daarvoor\neen specifieke reden heeft.\n"
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Geen stabiele release beschikbaar"
 
 #: downloads/templates/downloads-index.html:114
@@ -617,7 +617,7 @@ msgstr "Linux distributies"
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr "Ubuntu-gebruikers kunnen een PPA\nvoor ontwikkelings- en stabiele-versies van Dolphin hier installeren: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\"> Dolphin installeren</a>"
 

--- a/dolweb/locale/pl/LC_MESSAGES/django.po
+++ b/dolweb/locale/pl/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Damian Kacperski <7dami77@gmail.com>, 2021
 # Pierre Bourdon <delroth@gmail.com>, 2013
@@ -601,20 +601,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Wersje stabilne"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Brak stabilnych wersji"
 
 #: downloads/templates/downloads-index.html:114
@@ -624,7 +624,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/pt/LC_MESSAGES/django.po
+++ b/dolweb/locale/pt/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # João Frade <100nome.portugal@gmail.com>, 2013
 # João Frade <100nome.portugal@gmail.com>, 2013-2015
@@ -593,20 +593,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Versões estáveis"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Sem versões estáveis de momento"
 
 #: downloads/templates/downloads-index.html:114
@@ -616,7 +616,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/pt_BR/LC_MESSAGES/django.po
+++ b/dolweb/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Charles Fernando da Silva <eu.charles@hotmail.com>, 2013,2015
 # Felipefpl, 2015
@@ -598,20 +598,20 @@ msgid ""
 msgstr "As versões de desenvolvimento para Windows <b>exigem</b> que o <a href=\"https://learn.microsoft.com/pt-BR/cpp/windows/latest-supported-vc-redist\">Pacote Redistribuível de 64 bits do Visual C++ para o Visual Studio 2022</a> esteja instalado."
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Versões estáveis"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr "\n    As versões estáveis listadas abaixo não são atualizadas há anos e não possuem diversos recursos e correções de bugs presentes nas versões mais recentes.\n    As <a href=\"#download-beta\">versões beta</a> ou <a href=\"#download-dev\">de desenvolvimento</a> são\n    escolhas melhores para praticamente todos os usuários; versões estáveis só devem ser utilizadas se você tiver\n    um motivo específico para elas.\n"
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Nenhuma versão estável no momento"
 
 #: downloads/templates/downloads-index.html:114
@@ -621,7 +621,7 @@ msgstr "Distribuições Linux"
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr "Usuários do Ubuntu podem instalar um PPA\n    para as versões estáveis e de desenvolvimento do Dolphin aqui: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Instalando o Dolphin</a>\n    "
 

--- a/dolweb/locale/ro/LC_MESSAGES/django.po
+++ b/dolweb/locale/ro/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Arian - Cazare Muncitori <arianserv@gmail.com>, 2014
 msgid ""
@@ -592,20 +592,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Versiuni stabile"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Nu există încă nici-o versiune stabilă"
 
 #: downloads/templates/downloads-index.html:114
@@ -615,7 +615,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/ro_RO/LC_MESSAGES/django.po
+++ b/dolweb/locale/ro_RO/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Arian - Cazare Muncitori <arianserv@gmail.com>, 2014
 msgid ""
@@ -526,7 +526,7 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
@@ -539,24 +539,24 @@ msgstr ""
 #: downloads/templates/downloads-index.html:51
 msgid ""
 "\n"
-"    Release candidate versions are released to test an upcoming stable release of\n"
-"    Dolphin. They are generally more stable than the Development versions, but may still have known bugs.\n"
+"    Release candidate versions are released to test an upcoming legacy release of\n"
+"    Dolphin. They are generally more legacy than the Development versions, but may still have known bugs.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:74
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Versiuni stabile"
 
 #: downloads/templates/downloads-index.html:76
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr "\n    Versiunile Stabile sunt lansate după testări amănunțite, pentru a asigura\n    performanţă şi stabilitate la emulare. Totuşi, deoarece acestea sunt lansate\n     mai rar, ar putea fi depăşite şi lipsite de unele caracteristici noi.\n"
 
 #: downloads/templates/downloads-index.html:98
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Nu există încă nici-o versiune stabilă"
 
 #: downloads/templates/downloads-index.html:105
@@ -566,7 +566,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:106
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/ru/LC_MESSAGES/django.po
+++ b/dolweb/locale/ru/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Pierre Bourdon <delroth@gmail.com>, 2013
 # dffggff <nanoposan69@gmail.com>, 2013
@@ -601,20 +601,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Стабильные версии"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Стабильных версий сейчас нет"
 
 #: downloads/templates/downloads-index.html:114
@@ -624,7 +624,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/sk/LC_MESSAGES/django.po
+++ b/dolweb/locale/sk/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -526,26 +526,26 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:63
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:65
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:87
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:94
@@ -555,7 +555,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:95
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/sl/LC_MESSAGES/django.po
+++ b/dolweb/locale/sl/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -526,26 +526,26 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:63
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:65
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:87
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:94
@@ -555,7 +555,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:95
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/sr/LC_MESSAGES/django.po
+++ b/dolweb/locale/sr/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -525,26 +525,26 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:63
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:65
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:87
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:94
@@ -554,7 +554,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:95
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/sv/LC_MESSAGES/django.po
+++ b/dolweb/locale/sv/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # A. Regnander <anton_r_3@hotmail.com>, 2013-2014
 # A. Regnander <anton_r_3@hotmail.com>, 2015
@@ -595,20 +595,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Stabila versioner"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Det finns ingen stabil version ännu"
 
 #: downloads/templates/downloads-index.html:114
@@ -618,7 +618,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/template.pot
+++ b/dolweb/locale/template.pot
@@ -595,23 +595,23 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless "
+"    The legacy versions below are years out of date and missing countless "
 "features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev"
 "\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be "
+"    better choice for almost all users; the legacy versions should only be "
 "used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:114
@@ -621,7 +621,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://"
+"    for development and legacy versions of Dolphin here: <a href=\"https://"
 "wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing "
 "Dolphin</a>\n"
 "    "

--- a/dolweb/locale/th/LC_MESSAGES/django.po
+++ b/dolweb/locale/th/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # BoatKung <boatkung20@gmail.com>, 2013,2016,2018
 msgid ""
@@ -588,20 +588,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "เวอร์ชันสมบูรณ์"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "ยังไม่มีการปล่อยเวอร์ชันสมบูรณ์"
 
 #: downloads/templates/downloads-index.html:114
@@ -611,7 +611,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/th_TH/LC_MESSAGES/django.po
+++ b/dolweb/locale/th_TH/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # BoatKung <boatkung20@gmail.com>, 2013
 # BoatKung <boatkung20@gmail.com>, 2013,2016
@@ -525,26 +525,26 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:63
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "เวอร์ชันสมบูรณ์"
 
 #: downloads/templates/downloads-index.html:65
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:87
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "ยังไม่มีการปล่อยเวอร์ชันสมบูรณ์"
 
 #: downloads/templates/downloads-index.html:94
@@ -554,7 +554,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:95
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/tr/LC_MESSAGES/django.po
+++ b/dolweb/locale/tr/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Bahadır Usta <bahadirusta@hotmail.com.tr>, 2017
 # Mustafa Can <m.can.elmaci@gmail.com>, 2013
@@ -592,20 +592,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Kararlı sürümler"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Şu anda kararlı sürüm yok"
 
 #: downloads/templates/downloads-index.html:114
@@ -615,7 +615,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/uk/LC_MESSAGES/django.po
+++ b/dolweb/locale/uk/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -526,26 +526,26 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:63
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:65
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:87
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:94
@@ -555,7 +555,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:95
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/vi/LC_MESSAGES/django.po
+++ b/dolweb/locale/vi/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Hoàng Hải <boly456@gmail.com>, 2016
 # Anh Phan <vietnamesel10n@gmail.com>, 2013
@@ -590,20 +590,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "Phiên bản ổn định"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "Hiện chưa phát hành phiên bản ổn định"
 
 #: downloads/templates/downloads-index.html:114
@@ -613,7 +613,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/vi_VN/LC_MESSAGES/django.po
+++ b/dolweb/locale/vi_VN/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -523,7 +523,7 @@ msgid ""
 "    <p>Development versions are released every time a developer makes a change to\n"
 "    Dolphin, several times every day! Using development versions enables you to\n"
 "    use the latest and greatest improvements to the project. They are however\n"
-"    less tested than stable versions of the emulator.</p>\n"
+"    less tested than legacy versions of the emulator.</p>\n"
 "\n"
 "    <p>The development versions require the <a href=\"https://www.microsoft.com/en-us/download/details.aspx?id=48145\">64-bit Visual C++ redistributable for Visual Studio 2015</a>\n"
 "    to be installed.</p>\n"
@@ -536,24 +536,24 @@ msgstr ""
 #: downloads/templates/downloads-index.html:51
 msgid ""
 "\n"
-"    Release candidate versions are released to test an upcoming stable release of\n"
-"    Dolphin. They are generally more stable than the Development versions, but may still have known bugs.\n"
+"    Release candidate versions are released to test an upcoming legacy release of\n"
+"    Dolphin. They are generally more legacy than the Development versions, but may still have known bugs.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:74
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:76
 msgid ""
 "\n"
-"    Stable versions are released after a lot of testing to ensure emulation\n"
+"    Legacy versions are released after a lot of testing to ensure emulation\n"
 "    performance and stability. However, since they are released less often,\n"
 "    they might be outdated and lacking some new features.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:98
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:105
@@ -563,7 +563,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:106
 msgid ""
 "Ubuntu 14.10 and older users can install a PPA \n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/locale/zh_CN/LC_MESSAGES/django.po
+++ b/dolweb/locale/zh_CN/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Yueyu <lxfly2000@outlook.com>, 2014
 # Yueyu <lxfly2000@outlook.com>, 2015
@@ -597,20 +597,20 @@ msgid ""
 msgstr "Windows 系统上的开发版本<b>要求</b>安装 <a href=\"https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads\">Visual Studio 2022 的 64 位 Visual C++ 运行时组件</a>。"
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "稳定版本"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr "\n    以下的稳定版本已过时多年，缺少许多功能和错误修复。\n    <a href=\"#download-beta\">测试版本</a>或<a href=\"#download-dev\">开发版本</a>是更好的选择；\n只有在您有特定需求时，才应使用稳定版本。\n"
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "尚无稳定版本"
 
 #: downloads/templates/downloads-index.html:114
@@ -620,7 +620,7 @@ msgstr "Linux 发行版"
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr "Ubuntu 的用户可以到这里添加 PPA \n来安装开发版或稳定版 Dolphin: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">安装 Dolphin</a>"
 

--- a/dolweb/locale/zh_TW/LC_MESSAGES/django.po
+++ b/dolweb/locale/zh_TW/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Hydriz Scholz <hydriz@jorked.com>, 2013
 # Hydriz Scholz <hydriz@jorked.com>, 2013
@@ -593,20 +593,20 @@ msgid ""
 msgstr ""
 
 #: downloads/templates/downloads-index.html:81
-msgid "Stable versions"
+msgid "Legacy versions"
 msgstr "穩定版本"
 
 #: downloads/templates/downloads-index.html:84
 msgid ""
 "\n"
-"    The stable versions below are years out of date and missing countless features and bug fixes.\n"
+"    The legacy versions below are years out of date and missing countless features and bug fixes.\n"
 "    <a href=\"#download-beta\">Beta</a> or <a href=\"#download-dev\">development</a> versions are a\n"
-"    better choice for almost all users; the stable versions should only be used if you have\n"
+"    better choice for almost all users; the legacy versions should only be used if you have\n"
 "    a specific need for them.\n"
 msgstr ""
 
 #: downloads/templates/downloads-index.html:107
-msgid "No stable release yet"
+msgid "No legacy release yet"
 msgstr "尚無穩定版本"
 
 #: downloads/templates/downloads-index.html:114
@@ -616,7 +616,7 @@ msgstr ""
 #: downloads/templates/downloads-index.html:115
 msgid ""
 "Ubuntu users can install a PPA\n"
-"    for development and stable versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
+"    for development and legacy versions of Dolphin here: <a href=\"https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu\">Installing Dolphin</a>\n"
 "    "
 msgstr ""
 

--- a/dolweb/static/css/dolphin.css
+++ b/dolweb/static/css/dolphin.css
@@ -131,11 +131,11 @@ h5:hover a.headerlink {
     padding-bottom: 0.5em;
 }
 
-div#download-stable, div#download-dev {
+div#download-legacy, div#download-dev {
     margin-bottom: 3em;
 }
 
-div#download-stable h1, div#download-dev h1, div#download-source h1 {
+div#download-legacy h1, div#download-dev h1, div#download-source h1 {
     margin-bottom: 0.5em;
 }
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -21,7 +21,7 @@ def deploy(c, root, branch):
 
 @task(hosts=_HOSTS)
 def deploy_stable(c):
-    deploy(c, "/home/dolphin-emu/apps/www", "stable")
+    deploy(c, "/home/dolphin-emu/apps/www", "legacy")
 
 @task(hosts=_HOSTS)
 def deploy_dev(c):

--- a/fabfile.py
+++ b/fabfile.py
@@ -21,7 +21,7 @@ def deploy(c, root, branch):
 
 @task(hosts=_HOSTS)
 def deploy_stable(c):
-    deploy(c, "/home/dolphin-emu/apps/www", "legacy")
+    deploy(c, "/home/dolphin-emu/apps/www", "stable")
 
 @task(hosts=_HOSTS)
 def deploy_dev(c):


### PR DESCRIPTION
to the best of my knowledge this is only done on instances of the entire word, matching case sensitivity

I'm not sure if/how this would break non-English languages, feedback on that is welcome