### PR TITLE
update: Add 'info' endpoint to request information about a Dolphin version.

### DIFF
--- a/dolweb/update/urls.py
+++ b/dolweb/update/urls.py
@@ -8,9 +8,14 @@ urlpatterns = [
     # /update/latest/beta/
     url(r'^latest/(?P<track>\w+)/?$', views.latest, name='update_latest'),
 
-    # /update/check/dev/0000000...000
-    # /update/check/beta/000000...000
+    # /update/check/v1/dev/0000000000000000000000000000000000000000/win
+    # /update/check/v1/beta/0000000000000000000000000000000000000000/win
     url(r'^check/v(?P<updater_ver>\d+)/(?P<track>\w+)/(?P<version>[0-9a-f]{40})/?(?P<platform>[A-Za-z0-9-_]+)?$',
         views.check,
         name='update_check'),
+
+    # /update/info/v1/0000000000000000000000000000000000000000/win
+    url(r'^info/v(?P<updater_ver>\d+)/(?P<version>[0-9a-f]{40})/?(?P<platform>[A-Za-z0-9-_]+)?$',
+        views.info,
+        name='update_info'),
 ]


### PR DESCRIPTION
This adds an endpoint (eg. https://dolphin-emu.org/update/info/v1/9ebfcebddee0840e3cd86b090f892393efdba303/win) to retrieve the same information that the 'check' endpoint gives, but without binding it to an update track.

As for why: There were some ideas about letting the Updater just download a Dolphin version from scratch, so we could just distribute the Updater and let it handle actually downloading Dolphin. To do that, there needs to be a way to retrieve the manifest URL for any given Dolphin version without already having a Dolphin version, which appears to be impossible at the moment -- https://dolphin-emu.org/update/check/v1/dev/9ebfcebddee0840e3cd86b090f892393efdba303/win just returns 'up-to-date', and https://dolphin-emu.org/update/latest/dev does not return a manifest URL.

With this, you can first fetch https://dolphin-emu.org/update/latest/dev to get the current version hash, then use https://dolphin-emu.org/update/info/v1/9ebfcebddee0840e3cd86b090f892393efdba303/win to get the manifest and content store URL for the files, and then just download the files as the Updater already does during a normal update.

(We could also maybe use this to fix the bisect tool one of these days...)

I haven't tested this, since I'm not sure how.