### PR TITLE
remove mention of the Ubuntu ppa 

### DIFF
--- a/dolweb/downloads/templates/downloads-index.html
+++ b/dolweb/downloads/templates/downloads-index.html
@@ -105,10 +105,7 @@ src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 
 <div id="other-linux">
     <h1>{% trans "Linux distributions" %}</h1>
-    <p>{% blocktrans %}Ubuntu users can install a PPA
-    for development and legacy versions of Dolphin here: <a href="https://wiki.dolphin-emu.org/index.php?title=Installing_Dolphin#Ubuntu">Installing Dolphin</a>
-    {% endblocktrans %}</p>
-    <p>{% blocktrans %}Users of other Linux distributions can look here to compile Dolphin: <a href="https://wiki.dolphin-emu.org/index.php?title=Building_Dolphin_on_Linux">Building Dolphin on Linux</a>
+    <p>{% blocktrans %}Users of Linux distributions can look here to compile Dolphin: <a href="https://wiki.dolphin-emu.org/index.php?title=Building_Dolphin_on_Linux">Building Dolphin on Linux</a>
     {% endblocktrans %}</p>
 </div>
 


### PR DESCRIPTION
remove mention of the  Ubuntu ppa  due to the fact it no longer exists anymore . Since it no longer exist theirs no reason  to link it 