### PR TITLE
downloads: Handle duplicate version names

### DIFF
--- a/dolweb/downloads/templates/downloads-view-devrel.html
+++ b/dolweb/downloads/templates/downloads-view-devrel.html
@@ -17,6 +17,18 @@
     data-ad-slot="5299890518"></ins>
 </div>
 
+{% if dupes %}
+    {% for dupe in dupes %}{% with br=ver.revbranch hash=dupe.hash url=dupe.get_absolute_url %}
+        <p>{% blocktrans %}{{ br }} can also refer to <a href="{{ url }}">{{ hash }}</a>.{% endblocktrans %}</p>
+    {% endwith %}{% endfor %}
+
+    <p>{% blocktrans count num=dupes|length trimmed %}
+        Some or all of the download links below may be based on that version.
+        {% plural %}
+        Some or all of the download links below may be based on those versions.
+    {% endblocktrans %}</p>
+{% endif %}
+
 <div class="row">
     <div class="col-md-5">
         <dl>

--- a/dolweb/downloads/views.py
+++ b/dolweb/downloads/views.py
@@ -65,16 +65,20 @@ def buildlist(request):
 @render_to('downloads-view-devrel.html')
 def view_dev_release(request, hash):
     release = get_object_or_404(DevVersion, hash=hash)
+    releases = DevVersion.objects.filter(branch=release.branch,
+                                         shortrev=release.shortrev)
+    dupes = releases.exclude(hash=hash).order_by('date')
 
-    return { 'ver': release }
+    return { 'ver': release, 'dupes': dupes }
 
 @vary_on_headers('User-Agent')
 @render_to('downloads-view-devrel.html')
 def view_dev_release_by_name(request, branch, name):
     releases = get_list_or_404(DevVersion, branch=branch, shortrev=name)
     releases.sort(key=lambda ver: ver.date)
+    release, dupes = releases[0], releases[1:]
 
-    return { 'ver': releases[0] }
+    return { 'ver': release, 'dupes': dupes }
 
 @vary_on_headers('User-Agent')
 @render_to('downloads-view-release.html')

--- a/dolweb/downloads/views.py
+++ b/dolweb/downloads/views.py
@@ -5,7 +5,7 @@ from annoying.decorators import render_to
 from django.conf import settings
 from django.core.paginator import EmptyPage
 from django.http import Http404, HttpResponse, JsonResponse
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, get_list_or_404
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.vary import vary_on_headers
@@ -71,9 +71,10 @@ def view_dev_release(request, hash):
 @vary_on_headers('User-Agent')
 @render_to('downloads-view-devrel.html')
 def view_dev_release_by_name(request, branch, name):
-    release = get_object_or_404(DevVersion, branch=branch, shortrev=name)
+    releases = get_list_or_404(DevVersion, branch=branch, shortrev=name)
+    releases.sort(key=lambda ver: ver.date)
 
-    return { 'ver': release }
+    return { 'ver': releases[0] }
 
 @vary_on_headers('User-Agent')
 @render_to('downloads-view-release.html')


### PR DESCRIPTION
There are sometimes multiple versions with the same branch and name, such as [3.5-154 (00d303e)](https://dolphin-emu.org/download/dev/00d303eeadf23f394836ecd317eb800f0047a0bf/) and [3.5-154 (2844708)](https://dolphin-emu.org/download/dev/2844708c2d5d350c4e8b9d203964dfbd259f7762/). The current behavior is to assume that never happens, so you get a [500 response](https://dolphin-emu.org/download/dev/master/3.5-154/) if you look them up by name. This change defaults to the oldest version in that case and informs the visitor of the ambiguity.

This still needs to be tested; I don't know how to do so.