### PR TITLE
remove "recent" from intro

### DIFF
--- a/dolweb/homepage/templates/homepage-home.html
+++ b/dolweb/homepage/templates/homepage-home.html
@@ -37,7 +37,7 @@
             <h1 class="title">{% trans "Dolphin Emulator" %}</h1>
             <p class="intro">
             {% blocktrans %}
-            <b>Dolphin</b> is an emulator for two recent Nintendo video game
+            <b>Dolphin</b> is an emulator for two Nintendo video game
             consoles: the <b>GameCube</b> and the <b>Wii</b>. It allows PC
             gamers to enjoy games for these two consoles in <b>full HD</b>
             (1080p) with several enhancements: compatibility with all PC


### PR DESCRIPTION
At 25 and 20 years old, neither the GameCube nor the Wii count as a recent console.  Fun fact: we are further away in time from the GameCube (25) than the GameCube was from the release of the NES (18)!