### PR TITLE
downloads: Update MSVC requirement

### DIFF
--- a/dolweb/downloads/templates/downloads-index.html
+++ b/dolweb/downloads/templates/downloads-index.html
@@ -34,7 +34,7 @@
 </div>
 
 <div class="alert alert-danger">
-    <p>{% blocktrans %}The Windows releases <b>require</b> the <a href="https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170">64-bit Visual C++ redistributable for Visual Studio 2022</a> to be installed.{% endblocktrans %}</p>
+    <p>{% blocktrans %}The Windows releases <b>require</b> the <a href="https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist#visual-c-v14-redistributable">64-bit Visual C++ v14 redistributable</a> to be installed.{% endblocktrans %}</p>
 </div>
 
 {% include "downloads-release.html" with builds=releases primclass='btn-info' %}
@@ -57,7 +57,7 @@
 </div>
 
 <div class="alert alert-danger">
-    <p>{% blocktrans %}The Windows development versions <b>require</b> the <a href="https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170">64-bit Visual C++ redistributable for Visual Studio 2022</a> to be installed.{% endblocktrans %}</p>
+    <p>{% blocktrans %}The Windows development versions <b>require</b> the <a href="https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist#visual-c-v14-redistributable">64-bit Visual C++ 14 redistributable</a> to be installed.{% endblocktrans %}</p>
 </div>
 
 {% include "downloads-devrel.html" with builds=master_builds primclass='btn-info' %}


### PR DESCRIPTION
Those requirements were changed to require VS2026 in 2606-215. I wanted to wait until the next stable release to update both of these URLs, however since Visual C++ v14 bundles both 2022 and 2026, I suppose it's fine to update them pre-emptively.